### PR TITLE
Fixed make_chromarms

### DIFF
--- a/bioframe/genomeops.py
+++ b/bioframe/genomeops.py
@@ -9,7 +9,7 @@ def make_chromarms(
     chromsizes,
     midpoints,
     cols_chroms=("chrom", "length"),
-    cols_mids=("chrom", "mid"), #renamed mids to mid
+    cols_mids=("chrom", "mid"),
     suffixes=("_p", "_q"),
 ):
     """
@@ -40,7 +40,7 @@ def make_chromarms(
 
     if isinstance(chromsizes, pd.Series):
         df_chroms = (
-            pd.DataFrame(chromsizes).reset_index().rename(columns={"name": ck1}) #renamed index to name
+            pd.DataFrame(chromsizes).reset_index().rename(columns={"name": ck1})
         )
     elif isinstance(chromsizes, pd.DataFrame):
         df_chroms = chromsizes.copy()

--- a/bioframe/genomeops.py
+++ b/bioframe/genomeops.py
@@ -9,7 +9,7 @@ def make_chromarms(
     chromsizes,
     midpoints,
     cols_chroms=("chrom", "length"),
-    cols_mids=("chrom", "mids"),
+    cols_mids=("chrom", "mid"), #renamed mids to mid
     suffixes=("_p", "_q"),
 ):
     """
@@ -40,7 +40,7 @@ def make_chromarms(
 
     if isinstance(chromsizes, pd.Series):
         df_chroms = (
-            pd.DataFrame(chromsizes).reset_index().rename(columns={"index": ck1})
+            pd.DataFrame(chromsizes).reset_index().rename(columns={"name": ck1}) #renamed index to name
         )
     elif isinstance(chromsizes, pd.DataFrame):
         df_chroms = chromsizes.copy()
@@ -69,7 +69,7 @@ def make_chromarms(
         suffixes=suffixes,
     )
     df_chromarms["name"].replace(r"[\:\[].*?[\)\_]", "", regex=True, inplace=True)
-    df_chromarms.drop(columns=["index_2", "length"], inplace=True)
+    df_chromarms.drop(columns=["length"], inplace=True)
     return df_chromarms
 
 

--- a/bioframe/ops.py
+++ b/bioframe/ops.py
@@ -1249,7 +1249,7 @@ def split(
     df_split.rename(columns=name_updates, inplace=True)
 
     if add_names:
-        df_split = regions_add_name_column(df_split) #Problem with this function, deletes index_2
+        df_split = regions_add_name_column(df_split)
         sides = np.mod(df_split["index_2"].values, 2).astype(int)  # .astype(str)
         df_split["name"] = df_split["name"].values + np.array(suffixes)[sides]
         df_split.drop(columns=["index_2"], inplace=True)

--- a/bioframe/ops.py
+++ b/bioframe/ops.py
@@ -1249,10 +1249,10 @@ def split(
     df_split.rename(columns=name_updates, inplace=True)
 
     if add_names:
-        df_split = regions_add_name_column(df_split)
+        df_split = regions_add_name_column(df_split) #Problem with this function, deletes index_2
         sides = np.mod(df_split["index_2"].values, 2).astype(int)  # .astype(str)
         df_split["name"] = df_split["name"].values + np.array(suffixes)[sides]
-        df_split.drop(columns=["index_2"])
+        df_split.drop(columns=["index_2"], inplace=True)
 
     return df_split
 

--- a/bioframe/region.py
+++ b/bioframe/region.py
@@ -149,11 +149,12 @@ def regions_add_name_column(reg_df, cols=("chrom", "start", "end", "name")):
     cols are names of columns (unlikely to change)
     """
     if cols[3] in reg_df:
-        return reg_df[list(cols)]
+        return reg_df
+
     df = reg_df.copy()
     data = zip(df[cols[0]], df[cols[1]], df[cols[2]])
     df[cols[3]] = ["{0}:{1}-{2}".format(*i) for i in data]
-    return df[list(cols)]
+    return df
 
 
 def parse_regions(


### PR DESCRIPTION
Changed some variables and some functions to have better compatibility with other bio frame functions and cooler.

mids to mid because bioframe.fetch_centromeres('hg19') has column 'mid'

---------------------------------------------------------------------------
changed
pd.DataFrame(chromsizes).reset_index().rename(columns={"index": ck1})
to 
pd.DataFrame(chromsizes).reset_index().rename(columns={"index": ck1})

Reason:
cooler.chromsizes Series uses "name" rather than index

--------------------------------------------------------------------------
Fixed error on:
ops.split():

if add_names:
  df_split = regions_add_name_column(df_split)
  sides = np.mod(df_split["index_2"].values, 2).astype(int)  # .astype(str)  <---- causes error

Reason:
region.regions_add_name_column() doesn't only add "name" column but reformats to ("chrom", "start", "end", "name") getting rid of columns such as "index_2" and "length"

modified regions_add_name_column to only add "name" column without deleting other columns.

Also modified df_split.drop(columns=["index_2"]) to df_split.drop(columns=["index_2"], inplace=True)
because it wasn't dropping anything



