### PR TITLE
verify_column_names_informative-error-for-repeated-columns

### DIFF
--- a/bioframe/core/specs.py
+++ b/bioframe/core/specs.py
@@ -61,6 +61,9 @@ def _verify_columns(df, colnames, return_as_bool=False):
             return False
         raise ValueError("df is not a dataframe")
 
+    if len(set(colnames)) < len(colnames):
+        raise ValueError("column names must be unique")
+        
     if not set(colnames).issubset(df.columns):
         if return_as_bool:
             return False

--- a/tests/test_core_specs.py
+++ b/tests/test_core_specs.py
@@ -65,6 +65,10 @@ def test_verify_columns():
         return_as_bool=True,
     )
 
+    # no repeated column names
+    with pytest.raises(ValueError):
+        specs._verify_columns(df1, ["chromStart","chromStart"])
+
 
 def test_verify_column_dtypes():
 


### PR DESCRIPTION
adds informative repeated column name error, addresses https://github.com/open2c/bioframe/issues/61