### PR TITLE
make sure is_sorted works when df_view_col=None

### DIFF
--- a/bioframe/core/checks.py
+++ b/bioframe/core/checks.py
@@ -471,8 +471,8 @@ def is_sorted(
         view_name_col=view_name_col,
         cols=cols,
     )
-
-    if df.equals(df_sorted):
+    
+    if df.equals(df_sorted[df.columns]):
         return True
     else:
         return False

--- a/bioframe/core/checks.py
+++ b/bioframe/core/checks.py
@@ -471,7 +471,7 @@ def is_sorted(
         view_name_col=view_name_col,
         cols=cols,
     )
-    
+
     if df.equals(df_sorted[df.columns]):
         return True
     else:


### PR DESCRIPTION
fixing #94 - when `df_view_col=None`, 1 extra column gets added to `df_sorted`, which makes `df.equals(df_sorted)` always `False` - regardless of the sorting