### PR TITLE
Make expand throw an error if both pad and scale are passed

### DIFF
--- a/bioframe/ops.py
+++ b/bioframe/ops.py
@@ -188,7 +188,9 @@ def expand(df, pad=None, scale=None, side="both", cols=None):
     ck, sk, ek = _get_default_colnames() if cols is None else cols
     checks.is_bedframe(df, raise_errors=True, cols=[ck, sk, ek])
 
-    if scale is not None:
+    if scale is not None and pad is not None:
+        raise ValueError("only one of pad or scale can be supplied")
+    elif scale is not None:
         if scale < 0:
             raise ValueError("multiplicative scale must be >=0")
         pads = 0.5 * (scale - 1) * (df[ek].values - df[sk].values)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -397,6 +397,14 @@ def test_expand():
     )
     pd.testing.assert_frame_equal(df, fake_expanded)
 
+def test_expand_amount_args():
+    d = """chrom  start  end
+         0  chr1      3    5
+         1  chr1     52   55
+         2  chr2    110  200"""
+    df = pd.read_csv(StringIO(d), sep=r"\s+")
+    with pytest.raises(ValueError):
+        bioframe.expand(df, pad=10, scale=2.0)
 
 def test_overlap():
 


### PR DESCRIPTION
Adding a minor check to `bioframe.expand`. Throws an error if both `pad` and `scale` are passed.