### PR TITLE
Fix failing tests on 32-bit

### DIFF
--- a/bioframe/extras.py
+++ b/bioframe/extras.py
@@ -196,7 +196,7 @@ def digest(fasta_records, enzyme):
 
     def _each(chrom):
         seq = bioseq.Seq(str(fasta_records[chrom][:]))
-        cuts = np.r_[0, np.array(cut_finder(seq)) + 1, len(seq)].astype(int)
+        cuts = np.r_[0, np.array(cut_finder(seq)) + 1, len(seq)].astype(np.int64)
         n_frags = len(cuts) - 1
 
         frags = pd.DataFrame(

--- a/bioframe/ops.py
+++ b/bioframe/ops.py
@@ -217,7 +217,7 @@ def expand(df, pad=None, scale=None, side="both", cols=None):
 
     if pad is not None:
         if pad < 0:
-            mids = df[sk].values + (0.5 * (df[ek].values - df[sk].values)).astype(int)
+            mids = df[sk].values + (0.5 * (df[ek].values - df[sk].values)).astype(np.int64)
             df_expanded[sk] = np.minimum(df_expanded[sk].values, mids)
             df_expanded[ek] = np.maximum(df_expanded[ek].values, mids)
     if scale is not None:
@@ -628,8 +628,8 @@ def cluster(
             cluster_starts_group,
             cluster_ends_group,
         ) = arrops.merge_intervals(
-            df_group[sk].values.astype(int),
-            df_group[ek].values.astype(int),
+            df_group[sk].values.astype(np.int64),
+            df_group[ek].values.astype(np.int64),
             min_dist=min_dist,
         )
 
@@ -767,8 +767,8 @@ def merge(df, min_dist=0, cols=None, on=None):
             cluster_starts_group,
             cluster_ends_group,
         ) = arrops.merge_intervals(
-            df_group[sk].values.astype(int),
-            df_group[ek].values.astype(int),
+            df_group[sk].values.astype(np.int64),
+            df_group[ek].values.astype(np.int64),
             min_dist=min_dist
             # df_group[sk].values, df_group[ek].values, min_dist=min_dist
         )
@@ -1657,8 +1657,8 @@ def complement(df, view_df=None, view_name_col="name", cols=None, cols_view=None
         df_group = df.loc[df_group_idxs]
 
         (complement_starts_group, complement_ends_group,) = arrops.complement_intervals(
-            df_group[sk].values.astype(int),
-            df_group[ek].values.astype(int),
+            df_group[sk].values.astype(np.int64),
+            df_group[ek].values.astype(np.int64),
             bounds=(region_start, region_end),
         )
 

--- a/docs/requirements_doc.txt
+++ b/docs/requirements_doc.txt
@@ -1,4 +1,5 @@
 autodocsumm
 myst_nb
+jinja2<3.1
 sphinx<4,>=2.1
 sphinx_rtd_theme

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -5,6 +5,12 @@
 # Required
 version: 2
 
+# Specify Build OS
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
@@ -19,7 +25,6 @@ formats: all
 # Optionally set the version of Python and requirements required to build your docs
 # setup_py_install: true
 python:
-  version: 3.8
   install:
     - requirements: docs/requirements_rtd.txt
     - method: setuptools

--- a/tests/test_core_specs.py
+++ b/tests/test_core_specs.py
@@ -91,7 +91,7 @@ def test_verify_column_dtypes():
     df1["chromStart"] = df1["chromStart"].astype(pd.Int64Dtype())
     assert specs._verify_column_dtypes(df1, new_names, return_as_bool=True)
 
-    df1["C"] = df1["C"].str.replace("chr", "").astype(int)
+    df1["C"] = df1["C"].str.replace("chr", "").astype(np.int64)
     assert specs._verify_column_dtypes(df1, new_names, return_as_bool=True) is False
 
 


### PR DESCRIPTION
At many places results are typecasted into plain `int`s this chokes on 32 bit archs with:

```
_______________________________ test_complement ________________________________
    def test_complement():
        ### complementing a df with no intervals in chrX by a view with chrX should return entire chrX region
        df1 = pd.DataFrame(
            [["chr1", 1, 5], ["chr1", 3, 8], ["chr1", 8, 10], ["chr1", 12, 14]],
            columns=["chrom", "start", "end"],
....
>       pd.testing.assert_frame_equal(
            bioframe.complement(df1, view_df=df1_chromsizes), df1_complement
        )
E       AssertionError: Attributes of DataFrame.iloc[:, 1] (column name="start") are different
E       
E       Attribute "dtype" are different
E       [left]:  int32
E       [right]: int64

________________________________ test_subtract _________________________________
    def test_subtract():
        ### no intervals should be left after self-subtraction
        df1 = pd.DataFrame(
....
E       AssertionError: DataFrame are different
E       
E       DataFrame shape mismatch
E       [left]:  (2, 4)
E       [right]: (1, 4)
tests/test_ops.py:1131: AssertionError
```

This PR is an attempt to fix the same. Tested this, and it gets the tests green on 32-bit (i386) arch.