### PR TITLE
refactor: Refactor genomic range parsing

### DIFF
--- a/bioframe/core/stringops.py
+++ b/bioframe/core/stringops.py
@@ -184,6 +184,7 @@ def _parse_region_record(grange: tuple) -> Tuple[str, int, int]:
 def parse_region(
     grange: Union[str, tuple],
     chromsizes: Union[dict, pd.Series] = None,
+    *,
     check_bounds: bool = True,
 ) -> Tuple[str, int, int]:
     """

--- a/bioframe/core/stringops.py
+++ b/bioframe/core/stringops.py
@@ -1,5 +1,5 @@
-from typing import Union, Tuple
 import re
+from typing import Tuple, Union
 
 import pandas as pd
 
@@ -45,7 +45,7 @@ def to_ucsc_string(grange: Tuple[str, int, int]) -> str:
 
 def is_complete_ucsc_string(s: str) -> bool:
     """
-    Returns True if a string can be parsed into a completely informative 
+    Returns True if a string can be parsed into a completely informative
     (chrom, start, end) format.
 
     Parameters
@@ -138,7 +138,7 @@ def parse_region_string(s: str) -> Tuple[str, int, int]:
             raise ValueError(
                 f"Expected COORD; got unexpected token: {name}: {token}"
             )
-        
+
         return start, end
 
     parts = s.split(":")
@@ -146,12 +146,12 @@ def parse_region_string(s: str) -> Tuple[str, int, int]:
     chrom = parts[0].strip()
     if not len(chrom):
         raise ValueError("Chromosome name cannot be empty")
-    
+
     if len(parts) < 2:
         return (chrom, None, None)
-    
+
     start, end = _parse_range(parts[1])
-    
+
     return chrom, start, end
 
 
@@ -162,9 +162,9 @@ def _parse_region_record(grange: tuple) -> Tuple[str, int, int]:
     Parameters
     ----------
     grange : str or tuple
-        * A triple (chrom, start, end), where ``start`` or ``end`` may be 
+        * A triple (chrom, start, end), where ``start`` or ``end`` may be
         ``None``.
-        * A quadruple or higher-order tuple, e.g. (chrom, start, end, name). 
+        * A quadruple or higher-order tuple, e.g. (chrom, start, end, name).
         ``name`` and other fields will be ignored.
 
     Returns
@@ -182,7 +182,7 @@ def _parse_region_record(grange: tuple) -> Tuple[str, int, int]:
 
 
 def parse_region(
-    grange: Union[str, tuple], 
+    grange: Union[str, tuple],
     chromsizes: Union[dict, pd.Series] = None,
     check_bounds: bool = True,
 ) -> Tuple[str, int, int]:
@@ -193,15 +193,15 @@ def parse_region(
     ----------
     grange : str or tuple
         * A UCSC-style genomic range string, e.g. "chr5:10,100,000-30,000,000".
-        * A triple (chrom, start, end), where ``start`` or ``end`` may be 
+        * A triple (chrom, start, end), where ``start`` or ``end`` may be
         ``None``.
-        * A quadruple or higher-order tuple, e.g. (chrom, start, end, name). 
+        * A quadruple or higher-order tuple, e.g. (chrom, start, end, name).
         ``name`` and other fields will be ignored.
-    
+
     chromsizes : dict or Series, optional
-        Lookup table of sequence lengths for bounds checking and for 
+        Lookup table of sequence lengths for bounds checking and for
         filling in a missing end coordinate.
-    
+
     check_bounds : bool, optional [default: True]
         If True, check that the genomic range is within the bounds of the
         sequence.
@@ -218,18 +218,18 @@ def parse_region(
 
     Sequence names may contain any character except for whitespace and colon.
 
-    The start coordinate should be 0 or greater and the end coordinate should 
-    be less than or equal to the length of the sequence, if the latter is 
-    known. These are enforced when ``check_bounds`` is ``True``. 
-    
-    If the start coordinate is missing, it is assumed to be 0. If the end 
-    coordinate is missing and chromsizes are provided, it is replaced with the 
+    The start coordinate should be 0 or greater and the end coordinate should
+    be less than or equal to the length of the sequence, if the latter is
+    known. These are enforced when ``check_bounds`` is ``True``.
+
+    If the start coordinate is missing, it is assumed to be 0. If the end
+    coordinate is missing and chromsizes are provided, it is replaced with the
     length of the sequence.
 
     The end coordinate **must** be greater than or equal to the start.
 
     The start and end coordinates may be suffixed with k(b), M(b), or G(b)
-    multipliers, case-insentive. e.g. "chr1:1K-2M" is equivalent to 
+    multipliers, case-insentive. e.g. "chr1:1K-2M" is equivalent to
     "chr1:1000-2000000".
     """
     if isinstance(grange, str):

--- a/bioframe/core/stringops.py
+++ b/bioframe/core/stringops.py
@@ -163,9 +163,9 @@ def _parse_region_record(grange: tuple) -> Tuple[str, int, int]:
     ----------
     grange : str or tuple
         * A triple (chrom, start, end), where ``start`` or ``end`` may be
-        ``None``.
+          ``None``.
         * A quadruple or higher-order tuple, e.g. (chrom, start, end, name).
-        ``name`` and other fields will be ignored.
+          ``name`` and other fields will be ignored.
 
     Returns
     -------
@@ -195,9 +195,9 @@ def parse_region(
     grange : str or tuple
         * A UCSC-style genomic range string, e.g. "chr5:10,100,000-30,000,000".
         * A triple (chrom, start, end), where ``start`` or ``end`` may be
-        ``None``.
+          ``None``.
         * A quadruple or higher-order tuple, e.g. (chrom, start, end, name).
-        ``name`` and other fields will be ignored.
+          ``name`` and other fields will be ignored.
 
     chromsizes : dict or Series, optional
         Lookup table of sequence lengths for bounds checking and for

--- a/bioframe/core/stringops.py
+++ b/bioframe/core/stringops.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Union, Tuple
 import re
 
 import pandas as pd
@@ -26,7 +26,7 @@ RANGE_REGEX = re.compile(
 )
 
 
-def to_ucsc_string(grange: tuple[str, int, int]) -> str:
+def to_ucsc_string(grange: Tuple[str, int, int]) -> str:
     """
     Convert a grange to a UCSC string.
 
@@ -87,7 +87,7 @@ def _parse_humanized_int(s: str) -> int:
     return int(value)
 
 
-def parse_region_string(s: str) -> tuple[str, int, int]:
+def parse_region_string(s: str) -> Tuple[str, int, int]:
     """
     Parse a UCSC-style genomic range string into a triple.
 
@@ -155,7 +155,7 @@ def parse_region_string(s: str) -> tuple[str, int, int]:
     return chrom, start, end
 
 
-def _parse_region_record(grange: tuple) -> tuple[str, int, int]:
+def _parse_region_record(grange: tuple) -> Tuple[str, int, int]:
     """
     Coerce a genomic range record into a triple.
 
@@ -185,7 +185,7 @@ def parse_region(
     grange: Union[str, tuple], 
     chromsizes: Union[dict, pd.Series] = None,
     check_bounds: bool = True,
-) -> tuple[str, int, int]:
+) -> Tuple[str, int, int]:
     """
     Coerce a genomic range string or sequence type into a triple.
 

--- a/bioframe/core/stringops.py
+++ b/bioframe/core/stringops.py
@@ -1,4 +1,7 @@
+from typing import Union
 import re
+
+import pandas as pd
 
 __all__ = [
     "parse_region",
@@ -7,183 +10,251 @@ __all__ = [
     "to_ucsc_string",
 ]
 
-GRANGE_TOKEN_SPEC = [
+NUMERIC_REGEX = re.compile("([0-9,.]+)")
+
+RANGE_TOKEN_SPEC = [
     ("HYPHEN", r"-"),
     ("COORD", r"[0-9,]+(\.[0-9]*)?(?:[a-z]+)?"),
     ("OTHER", r".+"),
 ]
 
-GRANGE_REGEX = re.compile(
+RANGE_REGEX = re.compile(
     r"\s*" + r"|\s*".join(
-        rf"(?P<{name}>{token})" for name, token in GRANGE_TOKEN_SPEC
+        rf"(?P<{name}>{token})" for name, token in RANGE_TOKEN_SPEC
     ),
     re.IGNORECASE
 )
 
 
-def to_ucsc_string(triplet):
+def to_ucsc_string(grange: tuple[str, int, int]) -> str:
     """
-    Convert a triplet to a UCSC string.
+    Convert a grange to a UCSC string.
 
     Parameters
     ----------
-    triplet : (chrom, start, end)
+    grange : tuple or other iterable
+        chrom, start, end
 
     Returns
     -------
-    ucsc_string : str
-        UCSC-style string, 'chrom:start-end'
+    str
+        UCSC-style genomic range string, '{chrom}:{start}-{end}'
     """
-    return "{}:{}-{}".format(*triplet)
+    return "{}:{}-{}".format(*grange)
 
 
-def _parse_humanized(s):
-    _NUMERIC_RE = re.compile("([0-9,.]+)")
-    _, value, unit = _NUMERIC_RE.split(s.replace(",", ""))
+def is_complete_ucsc_string(s: str) -> bool:
+    """
+    Returns True if a string can be parsed into a completely informative 
+    (chrom, start, end) format.
+
+    Parameters
+    ----------
+    s : str
+
+    Returns
+    -------
+    bool
+        True if able to be parsed and ``end`` is known.
+
+    """
+    if not isinstance(s, str):
+        return False
+    _, _, end = parse_region_string(s)
+    if end is None:
+        return False
+    return True
+
+
+def _parse_humanized_int(s: str) -> int:
+    _, value, unit = NUMERIC_REGEX.split(s.replace(",", ""))
+
+    # No multiplier unit, just return the integer value
     if not len(unit):
         return int(value)
 
+    # Parse and apply the multiplier. Remaining decimal places are dropped.
     value = float(value)
     unit = unit.upper().strip()
     if unit in ("K", "KB"):
-        value *= 1000
+        value *= 1_000
     elif unit in ("M", "MB"):
-        value *= 1000000
+        value *= 1_000_000
     elif unit in ("G", "GB"):
-        value *= 1000000000
+        value *= 1_000_000_000
     else:
         raise ValueError(f"Unknown unit '{unit}'")
     return int(value)
 
 
-def parse_region_string(s):
+def parse_region_string(s: str) -> tuple[str, int, int]:
     """
-    Parse a UCSC-style genomic region string into a triple.
+    Parse a UCSC-style genomic range string into a triple.
 
     Parameters
     ----------
     s : str
-        UCSC-style string, e.g. "chr5:10,100,000-30,000,000". Ensembl and FASTA
-        style sequence names are allowed. Start coordinate must >0 and end coordinate
-        must be greater than or equal to start.
+        UCSC-style genomic range string, e.g. "chr5:10,100,000-30,000,000".
 
     Returns
     -------
-    triple : (str, int or None, int or None)
+    tuple
+        (str, int or None, int or None)
 
+    See also
+    --------
+    parse_region
     """
 
     def _tokenize(s):
-        for match in GRANGE_REGEX.finditer(s):
-            typ = match.lastgroup
-            yield typ, match.group(typ)
+        for match in RANGE_REGEX.finditer(s):
+            name = match.lastgroup
+            yield name, match.group(name)
 
-    def _check_token(typ, token, expected):
-        if typ is None:
+    def _parse_range(s):
+        token_stream = _tokenize(s)
+
+        name, token = next(token_stream, (None, None))
+        if name != "COORD":
             raise ValueError(
-                f"Expected {' or '.join(expected)} token missing")
+                f"Expected COORD; got unexpected token: {name}: {token}"
+            )
+        start = _parse_humanized_int(token)
+
+        name, token = next(token_stream, (None, None))
+        if name != "HYPHEN":
+            raise ValueError(
+                f"Expected HYPHEN; got unexpected token: {name}: {token}"
+            )
+
+        name, token = next(token_stream, (None, None))
+        if name is None:  # No end coordinate
+            end = None
+        elif name == "COORD":
+            end = _parse_humanized_int(token)
+            if end < start:
+                raise ValueError("End coordinate less than start")
         else:
-            if typ not in expected:
-                raise ValueError(f'Unexpected token "{token}"')
-
-    def _expect(tokens):
-        typ, token = next(tokens, (None, None))
-        _check_token(typ, token, ["COORD"])
-        start = _parse_humanized(token)
-
-        typ, token = next(tokens, (None, None))
-        _check_token(typ, token, ["HYPHEN"])
-
-        typ, token = next(tokens, (None, None))
-        if typ is None:
-            return start, None
-
-        _check_token(typ, token, ["COORD"])
-        end = _parse_humanized(token)
-        if end < start:
-            raise ValueError("End coordinate less than start")
-
+            raise ValueError(
+                f"Expected COORD; got unexpected token: {name}: {token}"
+            )
+        
         return start, end
 
     parts = s.split(":")
+
     chrom = parts[0].strip()
     if not len(chrom):
         raise ValueError("Chromosome name cannot be empty")
+    
     if len(parts) < 2:
         return (chrom, None, None)
-    start, end = _expect(_tokenize(parts[1]))
-    return (chrom, start, end)
+    
+    start, end = _parse_range(parts[1])
+    
+    return chrom, start, end
 
 
-def is_complete_ucsc_string(mystring):
+def _parse_region_record(grange: tuple) -> tuple[str, int, int]:
     """
-    Check if a string can be parsed into (`chrom`, `start`, `end`) format.
+    Coerce a genomic range record into a triple.
 
     Parameters
     ----------
-    mystring : str
+    grange : str or tuple
+        * A triple (chrom, start, end), where ``start`` or ``end`` may be 
+        ``None``.
+        * A quadruple or higher-order tuple, e.g. (chrom, start, end, name). 
+        ``name`` and other fields will be ignored.
 
     Returns
     -------
-    is_complete : bool
-        True if able to be parsed into (`chrom`, `start`, `end`) format.
-
+    tuple
+        A well-formed genomic range triple (str, int, int).
     """
-    if not isinstance(mystring, str):
-        return False
-    if len(parse_region_string(mystring)) != 3:
-        return False
-    if parse_region_string(mystring)[2] is None:
-        return False
-    return True
+    if len(grange) < 3:
+        raise ValueError("Length of a range record should be at least 3")
+    chrom, start, end = grange[:3]
+    chrom = str(chrom)
+    start = int(start) if start is not None else start
+    end = int(end) if end is not None else end
+    return chrom, start, end
 
 
-def parse_region(reg, chromsizes=None):
+def parse_region(
+    grange: Union[str, tuple], 
+    chromsizes: Union[dict, pd.Series] = None,
+    check_bounds: bool = True,
+) -> tuple[str, int, int]:
     """
-    Coerce a genomic region string or sequence into a triple (chrom, start, end).
-
-    Genomic regions are represented as half-open intervals (0-based starts,
-    1-based ends) along the length coordinate of a contig/scaffold/chromosome.
-    Start must be >= 0, and end coordinate must be >= start.
+    Coerce a genomic range string or sequence type into a triple.
 
     Parameters
     ----------
-    reg : str or tuple
-        UCSC-style genomic region string, or
-        Triple (chrom, start, end), where ``start`` or ``end`` may be ``None``.
-        Quadriple (chrom, start, end, name) (name is ignored).
-    chromsizes : mapping, optional
-        Lookup table of scaffold lengths to check against ``chrom`` and the
-        ``end`` coordinate. Required if ``end`` is not supplied.
+    grange : str or tuple
+        * A UCSC-style genomic range string, e.g. "chr5:10,100,000-30,000,000".
+        * A triple (chrom, start, end), where ``start`` or ``end`` may be 
+        ``None``.
+        * A quadruple or higher-order tuple, e.g. (chrom, start, end, name). 
+        ``name`` and other fields will be ignored.
+    
+    chromsizes : dict or Series, optional
+        Lookup table of sequence lengths for bounds checking and for 
+        filling in a missing end coordinate.
+    
+    check_bounds : bool, optional [default: True]
+        If True, check that the genomic range is within the bounds of the
+        sequence.
 
     Returns
     -------
-    triple : (str, int, int)
-        A well-formed genomic region triple (str, int, int)
+    tuple
+        A well-formed genomic range triple (str, int, int).
 
+    Notes
+    -----
+    Genomic ranges are interpreted as half-open intervals (0-based starts,
+    1-based ends) along the length coordinate of a sequence.
+
+    Sequence names may contain any character except for whitespace and colon.
+
+    The start coordinate should be 0 or greater and the end coordinate should 
+    be less than or equal to the length of the sequence, if the latter is 
+    known. These are enforced when ``check_bounds`` is ``True``. 
+    
+    If the start coordinate is missing, it is assumed to be 0. If the end 
+    coordinate is missing and chromsizes are provided, it is replaced with the 
+    length of the sequence.
+
+    The end coordinate **must** be greater than or equal to the start.
+
+    The start and end coordinates may be suffixed with k(b), M(b), or G(b)
+    multipliers, case-insentive. e.g. "chr1:1K-2M" is equivalent to 
+    "chr1:1000-2000000".
     """
-    if isinstance(reg, str):
-        chrom, start, end = parse_region_string(reg)
+    if isinstance(grange, str):
+        chrom, start, end = parse_region_string(grange)
     else:
-        if len(reg) not in [3, 4]:
-            raise ValueError("length of a region should be 3 or 4")
-        chrom, start, end = reg[:3]
-        start = int(start) if start is not None else start
-        end = int(end) if end is not None else end
+        chrom, start, end = _parse_region_record(grange)
 
-    try:
-        clen = chromsizes[chrom] if chromsizes is not None else None
-    except KeyError:
-        raise ValueError(f"Unknown sequence label: {chrom}")
+    # Fill in missing end coordinate if possible
+    clen = None
+    if chromsizes is not None:
+        try:
+            clen = chromsizes[chrom]
+        except KeyError:
+            raise ValueError(f"Unknown sequence label: {chrom}")
+        if end is None:
+            end = clen
 
-    start = 0 if start is None else start
-    if end is None:
-        end = clen  # if clen is None, end is None too!
+    # Fill in missing start coordinate
+    if start is None:
+        start = 0
 
-    if (end is not None) and (end < start):
+    if end is not None and (end < start):
         raise ValueError("End cannot be less than start")
 
-    if start < 0 or (clen is not None and end > clen):
-        raise ValueError(f"Genomic region out of bounds: [{start}, {end})")
+    if check_bounds and (start < 0 or (clen is not None and end > clen)):
+        raise ValueError(f"Genomic range out of bounds: [{start}, {end})")
 
     return chrom, start, end


### PR DESCRIPTION
Mostly stylistic changes and improved documentation for clarity.

Behavior changes:
* Added `check_bounds` option to `parse_region`, which is `True` by default (keeping current behavior).
* Relaxed `parse_region` to accept tuples of any length greater than 2 (not just 3 or 4), ignoring all fields after the first three.

