### PR TITLE
Preserve coordinate dtypes

### DIFF
--- a/bioframe/ops.py
+++ b/bioframe/ops.py
@@ -511,32 +511,16 @@ def overlap(
 
     # Masking non-overlapping regions if using non-inner joins.
     if how != "inner":
-        df_index_1[index_col_1] = df_index_1[index_col_1].convert_dtypes()
-        df_index_2[index_col_2] = df_index_2[index_col_2].convert_dtypes()
         df_index_1[events1 == -1] = None
         df_index_2[events2 == -1] = None
 
         if df_input_1 is not None:
-            df_input_1[sk1 + suffixes[0]] = (
-                df_input_1[sk1 + suffixes[0]].convert_dtypes()
-            )
-            df_input_1[ek1 + suffixes[0]] = (
-                df_input_1[ek1 + suffixes[0]].convert_dtypes()
-            )
             df_input_1[events1 == -1] = None
 
         if df_input_2 is not None:
-            df_input_2[sk2 + suffixes[1]] = (
-                df_input_2[sk2 + suffixes[1]].convert_dtypes()
-            )
-            df_input_2[ek2 + suffixes[1]] = (
-                df_input_2[ek2 + suffixes[1]].convert_dtypes()
-            )
             df_input_2[events2 == -1] = None
 
         if df_overlap is not None:
-            df_overlap[overlap_col_sk1] = df_overlap[overlap_col_sk1].convert_dtypes()
-            df_overlap[overlap_col_ek1] = df_overlap[overlap_col_ek1].convert_dtypes()
             df_overlap[(events1 == -1) | (events2 == -1)] = None
 
     out_df = pd.concat(

--- a/bioframe/ops.py
+++ b/bioframe/ops.py
@@ -516,13 +516,21 @@ def overlap(
         df_index_2[events2 == -1] = None
 
         if df_input_1 is not None:
-            df_input_1[sk1 + suffixes[0]] = df_input_1[sk1 + suffixes[0]].convert_dtypes()
-            df_input_1[ek1 + suffixes[0]] = df_input_1[ek1 + suffixes[0]].convert_dtypes()
+            df_input_1[sk1 + suffixes[0]] = (
+                df_input_1[sk1 + suffixes[0]].convert_dtypes()
+            )
+            df_input_1[ek1 + suffixes[0]] = (
+                df_input_1[ek1 + suffixes[0]].convert_dtypes()
+            )
             df_input_1[events1 == -1] = None
 
         if df_input_2 is not None:
-            df_input_2[sk2 + suffixes[1]] = df_input_2[sk2 + suffixes[1]].convert_dtypes()
-            df_input_2[ek2 + suffixes[1]] = df_input_2[ek2 + suffixes[1]].convert_dtypes()
+            df_input_2[sk2 + suffixes[1]] = (
+                df_input_2[sk2 + suffixes[1]].convert_dtypes()
+            )
+            df_input_2[ek2 + suffixes[1]] = (
+                df_input_2[ek2 + suffixes[1]].convert_dtypes()
+            )
             df_input_2[events2 == -1] = None
 
         if df_overlap is not None:

--- a/bioframe/ops.py
+++ b/bioframe/ops.py
@@ -280,10 +280,11 @@ def _overlap_intidxs(df1, df2, how="left", cols1=None, cols2=None, on=None):
     all_groups = set.union(set(df1_groups), set(df2_groups))
 
     # Extract coordinate columns
-    starts1 = df1[sk1].array
-    ends1 = df1[ek1].array
-    starts2 = df2[sk2].array
-    ends2 = df2[ek2].array
+    # .values will return a numpy array or pandas array, depending on the dtype
+    starts1 = df1[sk1].values
+    ends1 = df1[ek1].values
+    starts2 = df2[sk2].values
+    ends2 = df2[ek2].values
 
     # Find overlapping intervals per group (determined by chrom and on).
     overlap_intidxs = []


### PR DESCRIPTION
Changes `overlap` to preserve the underlying integer type of the coordinate columns <s>when casting output to nullable pandas dtypes.</s>

EDIT: Changed to least surprising behavior: 

1. Coordinate (`start` and `end`) columns in the input dataframes preserve dtypes in the output dataframe, when possible. 
2. Outer join operations that introduce null values into coordinate columns will exhibit the native casting behavior of the column dtype: i.e. numpy columns get cast to `float64` with NaNs while nullable pandas arrays remain unchanged (e.g. `UInt32` -> `UInt32`) and contain NAs.

If one is worried about input-dependent casting behavior, one can convert coord columns to nullable types before passing to `overlap` with the`.convert_dtypes()` method. `float64` output columns can also be forced into nullable `Int64` after overlap by applying `.convert_dtypes()` on the output.