### PR TITLE
cols and df_view_col passed to downstream functions

### DIFF
--- a/bioframe/core/checks.py
+++ b/bioframe/core/checks.py
@@ -3,7 +3,9 @@ import pandas as pd
 
 from .. import ops
 from . import construction
-from .specs import _get_default_colnames, _verify_column_dtypes, _verify_columns
+from .specs import _get_default_colnames
+from .specs import _verify_column_dtypes
+from .specs import _verify_columns
 
 __all__ = [
     "is_bedframe",
@@ -29,7 +31,8 @@ def is_bedframe(
 
     - chrom, start, end columns
     - columns have valid dtypes
-    - for each interval, if any of chrom, start, end are null, then all are null
+    - for each interval, if any of chrom, start, end are null, then all are
+        null
     - all starts < ends.
 
     Parameters
@@ -61,7 +64,10 @@ def is_bedframe(
             raise TypeError("Invalid bedFrame: Invalid column names")
         return False
 
-    if not _verify_column_dtypes(df, cols=[ck1, sk1, ek1], return_as_bool=True):
+    if not _verify_column_dtypes(
+            df,
+            cols=[ck1, sk1, ek1],
+            return_as_bool=True):
         if raise_errors:
             raise TypeError("Invalid bedFrame: Invalid column dtypes")
         return False
@@ -87,8 +93,12 @@ def is_bedframe(
 
 
 def is_cataloged(
-    df, view_df, raise_errors=False, df_view_col="view_region", view_name_col="name"
-):
+        df,
+        view_df,
+        raise_errors=False,
+        df_view_col="view_region",
+        view_name_col="name"
+        ):
     """
     Tests if all region names in `df[df_view_col]` are present in
     `view_df[view_name_col]`.
@@ -125,7 +135,10 @@ def is_cataloged(
 
     if not _verify_columns(view_df, [view_name_col], return_as_bool=True):
         if raise_errors:
-            raise ValueError(f"Could not find `{view_name_col}` column in view_df")
+            raise ValueError(
+                f"Could not find \
+                `{view_name_col}` \
+                column in view_df")
         return False
 
     if not set(df[df_view_col].copy().dropna().values).issubset(
@@ -171,7 +184,10 @@ def is_overlapping(df, cols=None):
     df_merged = merge(df, cols=cols)
 
     total_interval_len = np.sum((df[ek1] - df[sk1]).values)
-    total_interval_len_merged = np.sum((df_merged[ek1] - df_merged[sk1]).values)
+    total_interval_len_merged = np.sum(
+        (
+            df_merged[ek1] - df_merged[sk1]
+        ).values)
 
     if total_interval_len > total_interval_len_merged:
         return True
@@ -179,7 +195,11 @@ def is_overlapping(df, cols=None):
         return False
 
 
-def is_viewframe(region_df, raise_errors=False, view_name_col="name", cols=None):
+def is_viewframe(
+        region_df,
+        raise_errors=False,
+        view_name_col="name",
+        cols=None):
     """
     Checks that `region_df` is a valid viewFrame.
 
@@ -235,10 +255,12 @@ def is_viewframe(region_df, raise_errors=False, view_name_col="name", cols=None)
             raise ValueError("Invalid view: cannot contain NAs")
         return False
 
-    if len(set(region_df[view_name_col])) < len(region_df[view_name_col].values):
+    if len(set(region_df[view_name_col])) < \
+       len(region_df[view_name_col].values):
         if raise_errors:
             raise ValueError(
-                "Invalid view: entries in region_df[view_name_col] must be unique"
+                "Invalid view: entries in \
+                region_df[view_name_col] must be unique"
             )
         return False
 
@@ -277,13 +299,12 @@ def is_contained(
     df_view_col:
         Column from df used to associate interviews with view regions.
         Default `view_region`.
-    
+
     view_name_col:
         Column from view_df with view region names. Default `name`.
 
     cols: (str, str, str)
         Column names for chrom, start, end in df.
-    
     cols_view: (str, str, str)
         Column names for chrom, start, end in view_df.
 
@@ -294,15 +315,23 @@ def is_contained(
     """
     from ..ops import trim
     ck1, sk1, ek1 = _get_default_colnames() if cols is None else cols
-    ck2, sk2, ek2 =_get_default_colnames() if cols_view is None else cols_view
-    
+    ck2, sk2, ek2 = _get_default_colnames() if cols_view is None else cols_view
     if df_view_col is None:
         try:
-            df_view_assigned = ops.overlap(df, view_df, cols1=cols, cols2=cols_view)
-            assert (df_view_assigned[ek2 + "_"].isna()).sum() == 0 # ek2 = end_ is the default value
-            assert (df_view_assigned[sk2 + "_"].isna()).sum() == 0 # sk2 = start_ is the default value
-            assert (df_view_assigned[ek1] <= df_view_assigned[ek2 + "_"]).all() # ek1 = end is the default value
-            assert (df_view_assigned[sk1] >= df_view_assigned[sk2 + "_"]).all() # sk1 = start is the default value
+            df_view_assigned = ops.overlap(
+                df,
+                view_df,
+                cols1=cols,
+                cols2=cols_view
+            )
+            # ek2 = end_ is the default value
+            assert (df_view_assigned[ek2 + "_"].isna()).sum() == 0
+            # sk2 = start_ is the default value
+            assert (df_view_assigned[sk2 + "_"].isna()).sum() == 0
+            assert (df_view_assigned[ek1] <= df_view_assigned[ek2 + "_"]).all()
+            # ek1 = end is the default value
+            # sk1 = start is the default value
+            assert (df_view_assigned[sk1] >= df_view_assigned[sk2 + "_"]).all()
         except AssertionError:
             if raise_errors:
                 raise AssertionError("df not contained in view_df")
@@ -318,7 +347,12 @@ def is_contained(
         return False
 
     df_trim = trim(
-        df, view_df=view_df, df_view_col=df_view_col, view_name_col=view_name_col, cols=cols, cols_view=cols_view
+        df,
+        view_df=view_df,
+        df_view_col=df_view_col,
+        view_name_col=view_name_col,
+        cols=cols,
+        cols_view=cols_view
     )
 
     is_start_trimmed = np.any(df[sk1].values != df_trim[sk1].values)
@@ -358,7 +392,8 @@ def is_covering(df, view_df, view_name_col="name", cols=None, cols_view=None):
 
     cols_view: (str, str, str) or None
         The names of columns containing the chromosome, start and end of the
-        genomic intervals in view_df, provided separately for each set. The default
+        genomic intervals in view_df, provided separately for
+        each set. The default
         values are 'chrom', 'start', 'end'.
 
     Returns
@@ -420,10 +455,10 @@ def is_tiling(
         The names of columns containing the chromosome, start and end of the
         genomic intervals, provided separately for each set. The default
         values are 'chrom', 'start', 'end'.
-    
     cols_view: (str, str, str) or None
         The names of columns containing the chromosome, start and end of the
-        genomic intervals in view_df, provided separately for each set. The default
+        genomic intervals in view_df, provided
+        separately for each set. The default
         values are 'chrom', 'start', 'end'.
 
     Returns
@@ -440,12 +475,23 @@ def is_tiling(
         if raise_errors:
             raise ValueError("overlaps")
         return False
-    if not is_covering(df, view_df, view_name_col=view_name_col, cols=cols, cols_view=cols_view):
+    if not is_covering(
+        df,
+        view_df,
+        view_name_col=view_name_col,
+        cols=cols,
+        cols_view=cols_view
+            ):
         if raise_errors:
             raise ValueError("not covered")
         return False
     if not is_contained(
-        df, view_df, df_view_col=df_view_col, view_name_col=view_name_col, cols=cols, cols_view=cols_view
+        df,
+        view_df,
+        df_view_col=df_view_col,
+        view_name_col=view_name_col,
+        cols=cols,
+        cols_view=cols_view
     ):
         if raise_errors:
             raise ValueError("not contained")
@@ -492,10 +538,11 @@ def is_sorted(
         The names of columns containing the chromosome, start and end of the
         genomic intervals, provided separately for each set. The default
         values are 'chrom', 'start', 'end'.
-    
+
     cols_view: (str, str, str) or None
         The names of columns containing the chromosome, start and end of the
-        genomic intervals in view_df, provided separately for each set. The default
+        genomic intervals in view_df, provided separately for each set.
+        The default
         values are 'chrom', 'start', 'end'.
 
     Returns

--- a/bioframe/core/checks.py
+++ b/bioframe/core/checks.py
@@ -332,7 +332,7 @@ def is_contained(
         return True
 
 
-def is_covering(df, view_df, view_name_col="name", cols=None):
+def is_covering(df, view_df, view_name_col="name", cols=None, cols_view=None):
     """
     Tests if a view `view_df` is covered by the set of genomic intervals in
     the bedframe `df`.
@@ -368,6 +368,7 @@ def is_covering(df, view_df, view_name_col="name", cols=None):
         view_df=view_df,
         view_name_col=view_name_col,
         cols=cols,
+        cols_view=cols_view,
     ).empty:
         return True
     else:

--- a/bioframe/core/checks.py
+++ b/bioframe/core/checks.py
@@ -291,7 +291,7 @@ def is_contained(
 
     if df_view_col is None:
         try:
-            df_view_assigned = ops.overlap(df, view_df)
+            df_view_assigned = ops.overlap(df, view_df, cols1=cols, cols2=df_view_col)
             assert (df_view_assigned["end_"].isna()).sum() == 0
             assert (df_view_assigned["start_"].isna()).sum() == 0
             assert (df_view_assigned["end"] <= df_view_assigned["end_"]).all()

--- a/bioframe/core/checks.py
+++ b/bioframe/core/checks.py
@@ -257,6 +257,7 @@ def is_contained(
     df_view_col=None,
     view_name_col="name",
     cols=None,
+    view_cols=None,
 ):
     """
     Tests if all genomic intervals in a bioframe `df` are cataloged and do not
@@ -288,14 +289,15 @@ def is_contained(
     from ..ops import trim
 
     ck1, sk1, ek1 = _get_default_colnames() if cols is None else cols
-
+    view_cols = _get_default_colnames() if view_cols is None else view_cols
+    ck2, sk2, ek2 = [col + '_' for col in view_cols]
     if df_view_col is None:
         try:
-            df_view_assigned = ops.overlap(df, view_df, cols1=cols, cols2=df_view_col)
-            assert (df_view_assigned["end_"].isna()).sum() == 0
-            assert (df_view_assigned["start_"].isna()).sum() == 0
-            assert (df_view_assigned["end"] <= df_view_assigned["end_"]).all()
-            assert (df_view_assigned["start"] >= df_view_assigned["start_"]).all()
+            df_view_assigned = ops.overlap(df, view_df, cols1=cols, cols2=view_cols)
+            assert (df_view_assigned[ek2].isna()).sum() == 0 # ek2 = end_ is the default value
+            assert (df_view_assigned[sk2].isna()).sum() == 0 # sk2 = start_ is the default value
+            assert (df_view_assigned[ek1] <= df_view_assigned[ek2]).all() # ek1 = end is the default value
+            assert (df_view_assigned[sk1] >= df_view_assigned[sk2]).all() # sk1 = start is the default value
         except AssertionError:
             if raise_errors:
                 raise AssertionError("df not contained in view_df")

--- a/bioframe/core/checks.py
+++ b/bioframe/core/checks.py
@@ -356,6 +356,11 @@ def is_covering(df, view_df, view_name_col="name", cols=None, cols_view=None):
         genomic intervals, provided separately for each set. The default
         values are 'chrom', 'start', 'end'.
 
+    cols_view: (str, str, str) or None
+        The names of columns containing the chromosome, start and end of the
+        genomic intervals in view_df, provided separately for each set. The default
+        values are 'chrom', 'start', 'end'.
+
     Returns
     -------
     is_covering:bool
@@ -382,6 +387,7 @@ def is_tiling(
     df_view_col="view_region",
     view_name_col="name",
     cols=None,
+    cols_view=None,
 ):
     """
     Tests if a view `view_df` is tiled by the set of genomic intervals in the
@@ -414,6 +420,11 @@ def is_tiling(
         The names of columns containing the chromosome, start and end of the
         genomic intervals, provided separately for each set. The default
         values are 'chrom', 'start', 'end'.
+    
+    cols_view: (str, str, str) or None
+        The names of columns containing the chromosome, start and end of the
+        genomic intervals in view_df, provided separately for each set. The default
+        values are 'chrom', 'start', 'end'.
 
     Returns
     -------
@@ -422,19 +433,19 @@ def is_tiling(
     """
 
     view_df = construction.make_viewframe(
-        view_df, view_name_col=view_name_col, cols=cols
+        view_df, view_name_col=view_name_col, cols=cols_view
     )
 
-    if is_overlapping(df):
+    if is_overlapping(df, cols=cols):
         if raise_errors:
             raise ValueError("overlaps")
         return False
-    if not is_covering(df, view_df, view_name_col=view_name_col, cols=None):
+    if not is_covering(df, view_df, view_name_col=view_name_col, cols=cols, cols_view=cols_view):
         if raise_errors:
             raise ValueError("not covered")
         return False
     if not is_contained(
-        df, view_df, df_view_col=df_view_col, view_name_col=view_name_col, cols=None
+        df, view_df, df_view_col=df_view_col, view_name_col=view_name_col, cols=cols, cols_view=cols_view
     ):
         if raise_errors:
             raise ValueError("not contained")

--- a/bioframe/core/checks.py
+++ b/bioframe/core/checks.py
@@ -293,13 +293,8 @@ def is_contained(
 
     """
     from ..ops import trim
-    if cols is None :
-        cols = _get_default_colnames()
-    ck1, sk1, ek1 = cols
-    
-    if cols_view is None :
-        cols_view = _get_default_colnames()
-    ck2, sk2, ek2 = cols_view
+    ck1, sk1, ek1 = _get_default_colnames() if cols is None else cols
+    ck2, sk2, ek2 =_get_default_colnames() if cols_view is None else cols_view
     
     if df_view_col is None:
         try:

--- a/bioframe/core/checks.py
+++ b/bioframe/core/checks.py
@@ -295,27 +295,15 @@ def is_contained(
     from ..ops import trim
     if cols is None :
         cols = _get_default_colnames()
-
-    if len(cols) == 3 : 
-        ck1, sk1, ek1 = cols
-    
-    if len(cols) == 4 :
-        ck1, sk1, ek1, df_view_col =  cols
+    ck1, sk1, ek1 = cols
     
     if cols_view is None :
         cols_view = _get_default_colnames()
-    
-    if len(cols_view) == 3 :
-        ck2, sk2, ek2 = cols_view
-    
-    if len(cols_view) == 4 : 
-        ck2, sk2, ek2, view_name_col = cols_view
+    ck2, sk2, ek2 = cols_view
     
     if df_view_col is None:
         try:
             df_view_assigned = ops.overlap(df, view_df, cols1=cols, cols2=cols_view)
-            print('df_view_assigned')
-            print(df_view_assigned)
             assert (df_view_assigned[ek2 + "_"].isna()).sum() == 0 # ek2 = end_ is the default value
             assert (df_view_assigned[sk2 + "_"].isna()).sum() == 0 # sk2 = start_ is the default value
             assert (df_view_assigned[ek1] <= df_view_assigned[ek2 + "_"]).all() # ek1 = end is the default value
@@ -335,7 +323,7 @@ def is_contained(
         return False
 
     df_trim = trim(
-        df, view_df=view_df, df_view_col=df_view_col, view_name_col=view_name_col
+        df, view_df=view_df, df_view_col=df_view_col, view_name_col=view_name_col, cols=cols, cols_view=cols_view
     )
 
     is_start_trimmed = np.any(df[sk1].values != df_trim[sk1].values)

--- a/bioframe/core/checks.py
+++ b/bioframe/core/checks.py
@@ -2,11 +2,8 @@ import numpy as np
 import pandas as pd
 
 from . import construction
-from .specs import (
-    _get_default_colnames,
-    _verify_column_dtypes,
-    _verify_columns
-)
+from .specs import (_get_default_colnames, _verify_column_dtypes,
+                    _verify_columns)
 from .. import ops
 
 __all__ = [
@@ -66,10 +63,8 @@ def is_bedframe(
             raise TypeError("Invalid bedFrame: Invalid column names")
         return False
 
-    if not _verify_column_dtypes(
-            df,
-            cols=[ck1, sk1, ek1],
-            return_as_bool=True):
+    if not _verify_column_dtypes(df, cols=[ck1, sk1, ek1],
+                                 return_as_bool=True):
         if raise_errors:
             raise TypeError("Invalid bedFrame: Invalid column dtypes")
         return False
@@ -85,22 +80,18 @@ def is_bedframe(
 
     if ((df[ek1] - df[sk1]) < 0).any():
         if raise_errors:
-            raise ValueError(
-                f"Invalid bedframe: starts exceed ends for "
-                f"{sum((df[ek1] - df[sk1]) < 0)} intervals"
-            )
+            raise ValueError(f"Invalid bedframe: starts exceed ends for "
+                             f"{sum((df[ek1] - df[sk1]) < 0)} intervals")
         return False
 
     return True
 
 
-def is_cataloged(
-        df,
-        view_df,
-        raise_errors=False,
-        df_view_col="view_region",
-        view_name_col="name"
-        ):
+def is_cataloged(df,
+                 view_df,
+                 raise_errors=False,
+                 df_view_col="view_region",
+                 view_name_col="name"):
     """
     Tests if all region names in `df[df_view_col]` are present in
     `view_df[view_name_col]`.
@@ -137,23 +128,19 @@ def is_cataloged(
 
     if not _verify_columns(view_df, [view_name_col], return_as_bool=True):
         if raise_errors:
-            raise ValueError(
-                f"Could not find \
+            raise ValueError(f"Could not find \
                 `{view_name_col}` \
                 column in view_df")
         return False
 
     if not set(df[df_view_col].copy().dropna().values).issubset(
-        set(view_df[view_name_col].values)
-    ):
+            set(view_df[view_name_col].values)):
         if raise_errors:
             missing_regions = set(df[df_view_col].values).difference(
-                set(view_df[view_name_col].values)
-            )
+                set(view_df[view_name_col].values))
             raise ValueError(
                 f"The following regions in df[df_view_col] not in "
-                f"view_df[view_name_col]: \n{missing_regions}"
-            )
+                f"view_df[view_name_col]: \n{missing_regions}")
         return False
 
     return True
@@ -187,9 +174,7 @@ def is_overlapping(df, cols=None):
 
     total_interval_len = np.sum((df[ek1] - df[sk1]).values)
     total_interval_len_merged = np.sum(
-        (
-            df_merged[ek1] - df_merged[sk1]
-        ).values)
+        (df_merged[ek1] - df_merged[sk1]).values)
 
     if total_interval_len > total_interval_len_merged:
         return True
@@ -197,11 +182,10 @@ def is_overlapping(df, cols=None):
         return False
 
 
-def is_viewframe(
-        region_df,
-        raise_errors=False,
-        view_name_col="name",
-        cols=None):
+def is_viewframe(region_df,
+                 raise_errors=False,
+                 view_name_col="name",
+                 cols=None):
     """
     Checks that `region_df` is a valid viewFrame.
 
@@ -240,9 +224,8 @@ def is_viewframe(
 
     ck1, sk1, ek1 = _get_default_colnames() if cols is None else cols
 
-    if not _verify_columns(
-        region_df, [ck1, sk1, ek1, view_name_col], return_as_bool=True
-    ):
+    if not _verify_columns(region_df, [ck1, sk1, ek1, view_name_col],
+                           return_as_bool=True):
         if raise_errors:
             raise TypeError("Invalid view: invalid column names")
         return False
@@ -260,10 +243,8 @@ def is_viewframe(
     if len(set(region_df[view_name_col])) < \
        len(region_df[view_name_col].values):
         if raise_errors:
-            raise ValueError(
-                "Invalid view: entries in \
-                region_df[view_name_col] must be unique"
-            )
+            raise ValueError("Invalid view: entries in \
+                region_df[view_name_col] must be unique")
         return False
 
     if is_overlapping(region_df, cols=cols):
@@ -320,12 +301,10 @@ def is_contained(
     ck2, sk2, ek2 = _get_default_colnames() if cols_view is None else cols_view
     if df_view_col is None:
         try:
-            df_view_assigned = ops.overlap(
-                df,
-                view_df,
-                cols1=cols,
-                cols2=cols_view
-            )
+            df_view_assigned = ops.overlap(df,
+                                           view_df,
+                                           cols1=cols,
+                                           cols2=cols_view)
             # ek2 = end_ is the default value
             assert (df_view_assigned[ek2 + "_"].isna()).sum() == 0
             # sk2 = start_ is the default value
@@ -342,20 +321,17 @@ def is_contained(
         return True
 
     if not is_cataloged(
-        df, view_df, df_view_col=df_view_col, view_name_col=view_name_col
-    ):
+            df, view_df, df_view_col=df_view_col, view_name_col=view_name_col):
         if raise_errors:
             raise ValueError("df not cataloged in view_df")
         return False
 
-    df_trim = trim(
-        df,
-        view_df=view_df,
-        df_view_col=df_view_col,
-        view_name_col=view_name_col,
-        cols=cols,
-        cols_view=cols_view
-    )
+    df_trim = trim(df,
+                   view_df=view_df,
+                   df_view_col=df_view_col,
+                   view_name_col=view_name_col,
+                   cols=cols,
+                   cols_view=cols_view)
 
     is_start_trimmed = np.any(df[sk1].values != df_trim[sk1].values)
     is_end_trimmed = np.any(df[ek1].values != df_trim[ek1].values)
@@ -406,11 +382,11 @@ def is_covering(df, view_df, view_name_col="name", cols=None, cols_view=None):
     from ..ops import complement
 
     if complement(
-        df,
-        view_df=view_df,
-        view_name_col=view_name_col,
-        cols=cols,
-        cols_view=cols_view,
+            df,
+            view_df=view_df,
+            view_name_col=view_name_col,
+            cols=cols,
+            cols_view=cols_view,
     ).empty:
         return True
     else:
@@ -469,32 +445,28 @@ def is_tiling(
 
     """
 
-    view_df = construction.make_viewframe(
-        view_df, view_name_col=view_name_col, cols=cols_view
-    )
+    view_df = construction.make_viewframe(view_df,
+                                          view_name_col=view_name_col,
+                                          cols=cols_view)
 
     if is_overlapping(df, cols=cols):
         if raise_errors:
             raise ValueError("overlaps")
         return False
-    if not is_covering(
-        df,
-        view_df,
-        view_name_col=view_name_col,
-        cols=cols,
-        cols_view=cols_view
-            ):
+    if not is_covering(df,
+                       view_df,
+                       view_name_col=view_name_col,
+                       cols=cols,
+                       cols_view=cols_view):
         if raise_errors:
             raise ValueError("not covered")
         return False
-    if not is_contained(
-        df,
-        view_df,
-        df_view_col=df_view_col,
-        view_name_col=view_name_col,
-        cols=cols,
-        cols_view=cols_view
-    ):
+    if not is_contained(df,
+                        view_df,
+                        df_view_col=df_view_col,
+                        view_name_col=view_name_col,
+                        cols=cols,
+                        cols_view=cols_view):
         if raise_errors:
             raise ValueError("not contained")
         return False

--- a/bioframe/core/checks.py
+++ b/bioframe/core/checks.py
@@ -1,11 +1,13 @@
 import numpy as np
 import pandas as pd
 
-from .. import ops
 from . import construction
-from .specs import _get_default_colnames
-from .specs import _verify_column_dtypes
-from .specs import _verify_columns
+from .specs import (
+    _get_default_colnames,
+    _verify_column_dtypes,
+    _verify_columns
+)
+from .. import ops
 
 __all__ = [
     "is_bedframe",

--- a/bioframe/core/checks.py
+++ b/bioframe/core/checks.py
@@ -460,6 +460,7 @@ def is_sorted(
     df_view_col=None,
     view_name_col="name",
     cols=None,
+    cols_view=None,
 ):
     """
     Tests if a bedframe is changed by sorting.
@@ -491,6 +492,11 @@ def is_sorted(
         The names of columns containing the chromosome, start and end of the
         genomic intervals, provided separately for each set. The default
         values are 'chrom', 'start', 'end'.
+    
+    cols_view: (str, str, str) or None
+        The names of columns containing the chromosome, start and end of the
+        genomic intervals in view_df, provided separately for each set. The default
+        values are 'chrom', 'start', 'end'.
 
     Returns
     -------
@@ -506,6 +512,7 @@ def is_sorted(
         df_view_col=df_view_col,
         view_name_col=view_name_col,
         cols=cols,
+        cols_view=cols_view,
     )
 
     if df.equals(df_sorted):

--- a/bioframe/core/checks.py
+++ b/bioframe/core/checks.py
@@ -1,10 +1,9 @@
 import numpy as np
 import pandas as pd
 
-from . import construction
-from .specs import (_get_default_colnames, _verify_column_dtypes,
-                    _verify_columns)
 from .. import ops
+from . import construction
+from .specs import _get_default_colnames, _verify_column_dtypes, _verify_columns
 
 __all__ = [
     "is_bedframe",

--- a/tests/test_core_checks.py
+++ b/tests/test_core_checks.py
@@ -103,8 +103,39 @@ def test_is_contained():
     )
     # is contained, because assignments are inferred
     assert is_contained(df, view_df)
+    
+    # using previous assignments with non-standard column names in dataframes without argument
+    view_df = pd.DataFrame(
+        [
+            ["chr1", 0, 12, "chr1p"],
+            ["chr1", 13, 26, "chr1q"],
+            ["chrX", 1, 8, "chrX_0"],
+        ],
+        columns=["CHROM", "START", "END", "NAME"],
+    )
+    df = pd.DataFrame(
+        [
+            ["chr1", 12, 12, "chr1p"],
+            ["chr1", 13, 14, "chr1q"],
+            ["chrX", 1, 8, "chrX_0"],
+        ],
+        columns=["chrom1", "start1", "end1", "VIEW_REGION"],
+    )
+    assert is_contained(df, view_df, cols=["chrom1", "start1", "end1"], cols_view=["CHROM", "START", "END"], df_view_col="VIEW_REGION", view_name_col="NAME")
+
+    with pytest.raises(TypeError):
+        # cols and view_cols are not passed as an arguments
+        is_contained(df, view_df, raise_errors=True)
 
     # is not contained, because assignments are not inferred
+    view_df = pd.DataFrame(
+        [
+            ["chr1", 0, 12, "chr1p"],
+            ["chr1", 13, 26, "chr1q"],
+            ["chrX", 1, 8, "chrX_0"],
+        ],
+        columns=["chrom", "start", "end", "name"],
+    )
     assert not is_contained(df, view_df, df_view_col="view_region")
 
     ### second interval falls completely out of the view
@@ -381,3 +412,6 @@ def test_is_sorted():
 
     # view_df specifies a different ordering, so should not be sorted
     assert not is_sorted(bfs)
+
+if __name__ == '__main__':
+    test_is_contained()

--- a/tests/test_core_checks.py
+++ b/tests/test_core_checks.py
@@ -247,6 +247,30 @@ def test_is_tiling():
     chromsizes = [("chr1", 0, 9, "chr1p"), ("chr1", 11, 20, "chr1q")]
     assert is_tiling(df1, chromsizes)
 
+    ### testing for non-standard column names
+    df1 = pd.DataFrame(
+        [
+            ["chr1", 0, 9, "chr1p"],
+            ["chr1", 11, 12, "chr1q"],
+            ["chr1", 12, 20, "chr1q"],
+        ],
+        columns=["chrom1", "start1", "end1", "view_region"],
+    )
+    chromsizes = pd.DataFrame(
+        [
+            ["chr1", 0, 9, "chr1p"], 
+            ["chr1", 11, 20, "chr1q"]
+        ],
+        columns=["CHROM", "START", "END", "NAME"],
+        )
+    assert is_tiling(df1, chromsizes, cols=["chrom1", "start1", "end1"], cols_view=["CHROM", "START", "END"], view_name_col="NAME")
+
+    with pytest.raises(KeyError):
+        # cols and view_cols are not passed as an arguments
+        is_tiling(df1, chromsizes)
+
+
+
     ### not tiling, since (chr1,0,9) is associated with chr1q
     df1 = pd.DataFrame(
         [
@@ -437,3 +461,4 @@ def test_is_sorted():
 
 if __name__ == "__main__":
     test_is_covering()
+    test_is_tiling()

--- a/tests/test_core_checks.py
+++ b/tests/test_core_checks.py
@@ -18,7 +18,7 @@ from bioframe.ops import sort_bedframe
 
 
 def test_is_cataloged():
-    ### chr2q is not in view
+    #   chr2q is not in view
     view_df = pd.DataFrame(
         [
             ["chr1", 0, 12, "chr1p"],
@@ -38,7 +38,7 @@ def test_is_cataloged():
     )
     assert not is_cataloged(df, view_df)
 
-    ### chr1q is in view, df_view_col and view_name_col have funny labels.
+    #    chr1q is in view, df_view_col and view_name_col have funny labels.
     view_df = pd.DataFrame(
         [
             ["chr1", 0, 12, "chr1p"],
@@ -56,7 +56,10 @@ def test_is_cataloged():
         columns=["chrom", "start", "end", "funny_view_region"],
     )
     assert is_cataloged(
-        df, view_df, df_view_col="funny_view_region", view_name_col="funny_name"
+        df,
+        view_df,
+        df_view_col="funny_view_region",
+        view_name_col="funny_name"
     )
 
 
@@ -71,7 +74,7 @@ def test_is_contained():
         columns=["chrom", "start", "end", "name"],
     )
 
-    ### not contained because chr2q is not cataloged
+    #   not contained because chr2q is not cataloged
     df = pd.DataFrame(
         [
             ["chr1", 0, 12, "chr1p"],
@@ -82,7 +85,7 @@ def test_is_contained():
     )
     assert not is_contained(df, view_df, df_view_col="view_region")
 
-    ### not contained because second interval falls outside the view regions
+    #   not contained because second interval falls outside the view regions
     df = pd.DataFrame(
         [
             ["chr1", 14, 15, "chr1p"],
@@ -103,8 +106,9 @@ def test_is_contained():
     )
     # is contained, because assignments are inferred
     assert is_contained(df, view_df)
-    
-    # using previous assignments with non-standard column names in dataframes without argument
+
+    # using previous assignments with non-standard column names
+    # in dataframes without argument
     view_df = pd.DataFrame(
         [
             ["chr1", 0, 12, "chr1p"],
@@ -121,7 +125,14 @@ def test_is_contained():
         ],
         columns=["chrom1", "start1", "end1", "VIEW_REGION"],
     )
-    assert is_contained(df, view_df, cols=["chrom1", "start1", "end1"], cols_view=["CHROM", "START", "END"], df_view_col="VIEW_REGION", view_name_col="NAME")
+    assert is_contained(
+        df,
+        view_df,
+        cols=["chrom1", "start1", "end1"],
+        cols_view=["CHROM", "START", "END"],
+        df_view_col="VIEW_REGION",
+        view_name_col="NAME"
+        )
 
     with pytest.raises(TypeError):
         # cols and view_cols are not passed as an arguments
@@ -138,7 +149,7 @@ def test_is_contained():
     )
     assert not is_contained(df, view_df, df_view_col="view_region")
 
-    ### second interval falls completely out of the view
+    #   second interval falls completely out of the view
     df = pd.DataFrame(
         [
             ["chr1", 12, 12, "chr1p"],
@@ -156,7 +167,7 @@ def test_is_contained():
 
 
 def test_is_overlapping():
-    ### interval on chr1 overlaps
+    #   interval on chr1 overlaps
     d = """chrom  start  end
          0  chr1      3    6
          1  chr1     5   10
@@ -164,7 +175,7 @@ def test_is_overlapping():
     df = pd.read_csv(StringIO(d), sep=r"\s+")
     assert is_overlapping(df)
 
-    ### adjacent intervals do not overlap
+    #   adjacent intervals do not overlap
     d = """chrom  start  end
          0  chr1    3     6
          1  chr1    6    10
@@ -174,8 +185,8 @@ def test_is_overlapping():
 
 
 def test_is_covering():
-    ### test is_covering where an interval from df completely overlaps
-    ### two different regions from view
+    #   test is_covering where an interval from df completely overlaps
+    #   two different regions from view
     df1 = pd.DataFrame(
         [
             ["chr1", -5, 25],
@@ -185,8 +196,8 @@ def test_is_covering():
     chromsizes = [("chr1", 0, 9, "chr1p"), ("chr1", 11, 20, "chr1q")]
     assert is_covering(df1, chromsizes)
 
-    ### test is_covering where two intervals from df overlap
-    ### two different regions from view
+    #   test is_covering where two intervals from df overlap
+    #   two different regions from view
     df1 = pd.DataFrame(
         [
             ["chr1", -5, 10],
@@ -198,7 +209,7 @@ def test_is_covering():
     chromsizes = [("chr1", 0, 9, "chr1p"), ("chr1", 11, 20, "chr1q")]
     assert is_covering(df1, chromsizes)
 
-    ### test is_covering with non-standard columns names 
+    #   test is_covering with non-standard columns names
     df1 = pd.DataFrame(
         [
             ["chr1", -5, 10],
@@ -209,19 +220,25 @@ def test_is_covering():
     )
     chromsizes = pd.DataFrame(
         [
-            ["chr1", 0, 9, "chr1p"], 
+            ["chr1", 0, 9, "chr1p"],
             ["chr1", 11, 20, "chr1q"]
         ],
         columns=["CHROM", "START", "END", "NAME"],
         )
-    assert is_covering(df1, chromsizes, cols=["chrom1", "start1", "end1"], cols_view=["CHROM", "START", "END"], view_name_col="NAME")
+    assert is_covering(
+                        df1,
+                        chromsizes,
+                        cols=["chrom1", "start1", "end1"],
+                        cols_view=["CHROM", "START", "END"],
+                        view_name_col="NAME"
+                    )
 
     with pytest.raises(ValueError):
         # cols and view_cols are not passed as an arguments
         is_covering(df1, chromsizes)
 
-    ### test is_covering where two intervals from df overlap
-    ### two different regions from view
+    #   test is_covering where two intervals from df overlap
+    #   two different regions from view
     df1 = pd.DataFrame(
         [
             ["chr1", -5, 10, "chr1q"],
@@ -235,7 +252,7 @@ def test_is_covering():
 
 
 def test_is_tiling():
-    ### view region chr1p is tiled by one interval, chr1q is tiled by two
+    #   view region chr1p is tiled by one interval, chr1q is tiled by two
     df1 = pd.DataFrame(
         [
             ["chr1", 0, 9, "chr1p"],
@@ -247,7 +264,7 @@ def test_is_tiling():
     chromsizes = [("chr1", 0, 9, "chr1p"), ("chr1", 11, 20, "chr1q")]
     assert is_tiling(df1, chromsizes)
 
-    ### testing for non-standard column names
+    #   testing for non-standard column names
     df1 = pd.DataFrame(
         [
             ["chr1", 0, 9, "chr1p"],
@@ -258,20 +275,24 @@ def test_is_tiling():
     )
     chromsizes = pd.DataFrame(
         [
-            ["chr1", 0, 9, "chr1p"], 
+            ["chr1", 0, 9, "chr1p"],
             ["chr1", 11, 20, "chr1q"]
         ],
         columns=["CHROM", "START", "END", "NAME"],
         )
-    assert is_tiling(df1, chromsizes, cols=["chrom1", "start1", "end1"], cols_view=["CHROM", "START", "END"], view_name_col="NAME")
+    assert is_tiling(
+                        df1,
+                        chromsizes,
+                        cols=["chrom1", "start1", "end1"],
+                        cols_view=["CHROM", "START", "END"],
+                        view_name_col="NAME"
+                    )
 
     with pytest.raises(KeyError):
         # cols and view_cols are not passed as an arguments
         is_tiling(df1, chromsizes)
 
-
-
-    ### not tiling, since (chr1,0,9) is associated with chr1q
+    #  not tiling, since (chr1,0,9) is associated with chr1q
     df1 = pd.DataFrame(
         [
             ["chr1", 0, 9, "chr1q"],
@@ -283,7 +304,7 @@ def test_is_tiling():
     chromsizes = [("chr1", 0, 9, "chr1p"), ("chr1", 11, 20, "chr1q")]
     assert not is_tiling(df1, chromsizes)
 
-    ### not tiling, contains overlaps
+    #   not tiling, contains overlaps
     df1 = pd.DataFrame(
         [
             ["chr1", 0, 9, "chr1p"],
@@ -295,7 +316,7 @@ def test_is_tiling():
     chromsizes = [("chr1", 0, 9, "chr1p"), ("chr1", 11, 20, "chr1q")]
     assert not is_tiling(df1, chromsizes)
 
-    ### not tiling, since it doesn't cover
+    #   not tiling, since it doesn't cover
     df1 = pd.DataFrame(
         [
             ["chr1", 11, 12, "chr1q"],
@@ -308,7 +329,7 @@ def test_is_tiling():
 
 
 def test_is_bedframe():
-    ##missing a column
+    #   missing a column
     df1 = pd.DataFrame(
         [
             ["chr1", 11],
@@ -318,7 +339,7 @@ def test_is_bedframe():
     )
     assert not is_bedframe(df1)
 
-    ### end column has invalid dtype
+    #   end column has invalid dtype
     df1 = pd.DataFrame(
         [
             ["chr1", 10, "20"],
@@ -328,7 +349,7 @@ def test_is_bedframe():
     )
     assert not is_bedframe(df1)
 
-    ### second interval start > ends.
+    #   second interval start > ends.
     df1 = pd.DataFrame(
         [
             ["chr1", 10, 20],
@@ -338,7 +359,7 @@ def test_is_bedframe():
     )
     assert not is_bedframe(df1)
 
-    ### third interval has a null in one column
+    #   third interval has a null in one column
     df1 = pd.DataFrame(
         [
             ["chr1", 10, 20, "first"],
@@ -355,7 +376,7 @@ def test_is_bedframe():
     with pytest.raises(ValueError):
         is_bedframe(df1, raise_errors=True)
 
-    ### first interval is completely NA
+    # first interval is completely NA
     df1 = pd.DataFrame(
         [
             [pd.NA, pd.NA, pd.NA, "first"],
@@ -440,7 +461,7 @@ def test_is_sorted():
         view_df, view_df=view_df, view_name_col="fruit", df_view_col="fruit"
     )
 
-    ## testing for non-standard column names
+    # testing for non-standard column names
     view_df = pd.DataFrame(
         [
             ["chrX", 1, 8, "oranges"],
@@ -451,9 +472,14 @@ def test_is_sorted():
     )
 
     assert is_sorted(
-        view_df, view_df=view_df, view_name_col="FRUIT", df_view_col="FRUIT", cols=["CHROM", "START", "END"], cols_view=["CHROM", "START", "END"]
+        view_df,
+        view_df=view_df,
+        view_name_col="FRUIT",
+        df_view_col="FRUIT",
+        cols=["CHROM", "START", "END"],
+        cols_view=["CHROM", "START", "END"]
     )
-    
+
     with pytest.raises(ValueError):
         # cols and view_cols are not passed as an arguments
         is_sorted(view_df, view_df=view_df)
@@ -484,8 +510,3 @@ def test_is_sorted():
 
     # view_df specifies a different ordering, so should not be sorted
     assert not is_sorted(bfs)
-
-if __name__ == "__main__":
-    test_is_covering()
-    test_is_tiling()
-    test_is_sorted()

--- a/tests/test_core_checks.py
+++ b/tests/test_core_checks.py
@@ -198,6 +198,24 @@ def test_is_covering():
     chromsizes = [("chr1", 0, 9, "chr1p"), ("chr1", 11, 20, "chr1q")]
     assert is_covering(df1, chromsizes)
 
+    ### test is_covering with non-standard columns names 
+    df1 = pd.DataFrame(
+        [
+            ["chr1", -5, 10],
+            ["chr1", 11, 12],
+            ["chr1", 12, 20],
+        ],
+        columns=["chrom1", "start1", "end1"],
+    )
+    chromsizes = pd.DataFrame(
+        [
+            ["chr1", 0, 9, "chr1p"], 
+            ["chr1", 11, 20, "chr1q"]
+        ],
+        columns=["CHROM", "START", "END", "NAME"],
+        )
+    assert is_covering(df1, chromsizes, cols=["chrom1", "start1", "end1"], cols_view=["CHROM", "START", "END"], view_name_col="NAME")
+
     ### test is_covering where two intervals from df overlap
     ### two different regions from view
     df1 = pd.DataFrame(
@@ -412,3 +430,6 @@ def test_is_sorted():
 
     # view_df specifies a different ordering, so should not be sorted
     assert not is_sorted(bfs)
+
+if __name__ == "__main__":
+    test_is_covering()

--- a/tests/test_core_checks.py
+++ b/tests/test_core_checks.py
@@ -440,6 +440,24 @@ def test_is_sorted():
         view_df, view_df=view_df, view_name_col="fruit", df_view_col="fruit"
     )
 
+    ## testing for non-standard column names
+    view_df = pd.DataFrame(
+        [
+            ["chrX", 1, 8, "oranges"],
+            ["chrX", 8, 20, "grapefruit"],
+            ["chr1", 0, 10, "apples"],
+        ],
+        columns=["CHROM", "START", "END", "FRUIT"],
+    )
+
+    assert is_sorted(
+        view_df, view_df=view_df, view_name_col="FRUIT", df_view_col="FRUIT", cols=["CHROM", "START", "END"], cols_view=["CHROM", "START", "END"]
+    )
+    
+    with pytest.raises(ValueError):
+        # cols and view_cols are not passed as an arguments
+        is_sorted(view_df, view_df=view_df)
+
     df = pd.DataFrame(
         [
             ["chr1", 0, 10, "+"],
@@ -452,6 +470,14 @@ def test_is_sorted():
 
     assert not is_sorted(df)
 
+    view_df = pd.DataFrame(
+        [
+            ["chrX", 1, 8, "oranges"],
+            ["chrX", 8, 20, "grapefruit"],
+            ["chr1", 0, 10, "apples"],
+        ],
+        columns=["chrom", "start", "end", "fruit"],
+    )
     bfs = sort_bedframe(df, view_df=view_df, view_name_col="fruit")
 
     assert is_sorted(bfs, view_df=view_df, view_name_col="fruit")
@@ -462,3 +488,4 @@ def test_is_sorted():
 if __name__ == "__main__":
     test_is_covering()
     test_is_tiling()
+    test_is_sorted()

--- a/tests/test_core_checks.py
+++ b/tests/test_core_checks.py
@@ -412,6 +412,3 @@ def test_is_sorted():
 
     # view_df specifies a different ordering, so should not be sorted
     assert not is_sorted(bfs)
-
-if __name__ == '__main__':
-    test_is_contained()

--- a/tests/test_core_checks.py
+++ b/tests/test_core_checks.py
@@ -216,6 +216,10 @@ def test_is_covering():
         )
     assert is_covering(df1, chromsizes, cols=["chrom1", "start1", "end1"], cols_view=["CHROM", "START", "END"], view_name_col="NAME")
 
+    with pytest.raises(ValueError):
+        # cols and view_cols are not passed as an arguments
+        is_covering(df1, chromsizes)
+
     ### test is_covering where two intervals from df overlap
     ### two different regions from view
     df1 = pd.DataFrame(


### PR DESCRIPTION
- cols and df_view_cols passed to downstream functions.
- Running following example returns True and doesn't break
```
import bioframe as bf
import pandas as pd

cols = ['chrom', 'start', 'end']
data = [
    ('chr1', 1000000, 1250000),
    ('chr1', 1500000, 1750000),
    ('chr2', 1000000, 1300000),
    ('chr2', 2000000, 2300000)
]
df = pd.DataFrame(data, columns=cols)

# Create a sample DataFrame
view_cols = ['CHROM', 'START', 'END']
data = [
    ('chr1', 1000000, 1250000),
    ('chr1', 1500000, 1750000),
    ('chr2', 1000000, 1300000),
    ('chr2', 2000000, 2300000)
]
view_df = pd.DataFrame(data, columns=view_cols)

bf.is_contained(df, view_df, cols=cols, view_cols=view_cols)
```