### PR TITLE
Overlap point segment patch #183

### DIFF
--- a/bioframe/core/arrops.py
+++ b/bioframe/core/arrops.py
@@ -264,6 +264,23 @@ def _overlap_intervals_legacy(starts1, ends1, starts2, ends2, closed=False, sort
 
     return overlap_ids
 
+def get_pseudo_segment(starts, ends):
+    """
+    Get pseudo-segment for overlapping intervals.
+    
+    Parameters
+    ----------
+    starts, ends : numpy.ndarray
+
+    Returns
+    -------
+    pseudo_ends : numpy.ndarray
+        An array of pseudo-ends for overlapping intervals.
+    
+    """
+    pseudo_ends = ends.copy()
+    pseudo_ends[ends == starts] += 1
+    return [starts, pseudo_ends]
 
 def overlap_intervals(starts1, ends1, starts2, ends2, closed=False, sort=False):
     """
@@ -296,8 +313,11 @@ def overlap_intervals(starts1, ends1, starts2, ends2, closed=False, sort=False):
 
     starts1 = np.asarray(starts1)
     ends1 = np.asarray(ends1)
+    starts1, ends1 = get_pseudo_segment(starts1, ends1)
+
     starts2 = np.asarray(starts2)
     ends2 = np.asarray(ends2)
+    starts2, ends2 = get_pseudo_segment(starts2, ends2)
 
     # Concatenate intervals lists
     n1 = len(starts1)

--- a/bioframe/core/arrops.py
+++ b/bioframe/core/arrops.py
@@ -267,7 +267,7 @@ def _overlap_intervals_legacy(starts1, ends1, starts2, ends2, closed=False, sort
 def get_pseudo_segment(starts, ends):
     """
     Get pseudo-segment for overlapping intervals.
-    
+
     Parameters
     ----------
     starts, ends : numpy.ndarray
@@ -275,8 +275,7 @@ def get_pseudo_segment(starts, ends):
     Returns
     -------
     pseudo_ends : numpy.ndarray
-        An array of pseudo-ends for overlapping intervals.
-    
+    An array of pseudo-ends for overlapping intervals.
     """
     pseudo_ends = ends.copy()
     pseudo_ends[ends == starts] += 1

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -431,14 +431,14 @@ def test_overlap():
     df1 = pd.DataFrame(
         [
             ['chr1', 1, 1]
-        ], 
+        ],
         columns=['chrom','start','end']
     ).astype({"start": pd.Int64Dtype(), "end": pd.Int64Dtype()})
 
     df2 = pd.DataFrame(
         [
             ['chr1', 1, 2]
-        ], 
+        ],
         columns=['chrom','start','end']
     ).astype({"start": pd.Int64Dtype(), "end": pd.Int64Dtype()})
 
@@ -484,14 +484,14 @@ def test_overlap():
     df1 = pd.DataFrame(
         [
             ['chr1', 1, 1]
-        ], 
+        ],
         columns=['chrom','start','end']
     ).astype({"start": pd.Int64Dtype(), "end": pd.Int64Dtype()})
 
     df2 = pd.DataFrame(
         [
             ['chr1', 2, 2]
-        ], 
+        ],
         columns=['chrom','start','end']
     ).astype({"start": pd.Int64Dtype(), "end": pd.Int64Dtype()})
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -427,6 +427,94 @@ def test_overlap():
     )
     assert len(b) == 3
 
+    ### test overlap with point and segment data
+    df1 = pd.DataFrame(
+        [
+            ['chr1', 1, 1]
+        ], 
+        columns=['chrom','start','end']
+    ).astype({"start": pd.Int64Dtype(), "end": pd.Int64Dtype()})
+
+    df2 = pd.DataFrame(
+        [
+            ['chr1', 1, 2]
+        ], 
+        columns=['chrom','start','end']
+    ).astype({"start": pd.Int64Dtype(), "end": pd.Int64Dtype()})
+
+    b = bioframe.overlap(
+        df1,
+        df2,
+        on=None,
+        how="left",
+        return_index=True,
+        return_input=False,
+    )
+    assert np.sum(pd.isna(b["index_"].values)) == 0
+    b = bioframe.overlap(
+        df2,
+        df1,
+        on=None,
+        how="left",
+        return_index=True,
+        return_input=False,
+    )
+    assert np.sum(pd.isna(b["index_"].values)) == 0
+
+    b = bioframe.overlap(
+        df1,
+        df2,
+        on=None,
+        how="right",
+        return_index=True,
+        return_input=False,
+    )
+    assert np.sum(pd.isna(b["index"].values)) == 0
+    b = bioframe.overlap(
+        df2,
+        df1,
+        on=None,
+        how="right",
+        return_index=True,
+        return_input=False,
+    )
+    assert np.sum(pd.isna(b["index"].values)) == 0
+
+    ### Two adjacent point should not overlap with each other
+    df1 = pd.DataFrame(
+        [
+            ['chr1', 1, 1]
+        ], 
+        columns=['chrom','start','end']
+    ).astype({"start": pd.Int64Dtype(), "end": pd.Int64Dtype()})
+
+    df2 = pd.DataFrame(
+        [
+            ['chr1', 2, 2]
+        ], 
+        columns=['chrom','start','end']
+    ).astype({"start": pd.Int64Dtype(), "end": pd.Int64Dtype()})
+
+    b = bioframe.overlap(
+        df1,
+        df2,
+        on=None,
+        how="left",
+        return_index=True,
+        return_input=False,
+    )
+    assert np.sum(pd.isna(b["index_"].values)) == 1
+    b = bioframe.overlap(
+        df2,
+        df1,
+        on=None,
+        how="left",
+        return_index=True,
+        return_input=False,
+    )
+    assert np.sum(pd.isna(b["index_"].values)) == 1
+
+
     ### test keep_order and NA handling
     df1 = pd.DataFrame(
         [


### PR DESCRIPTION
This PR addresses [Issue](https://github.com/open2c/bioframe/issues/183).  Overlap operations between point and segment is fixed. 
```
import numpy as np
import bioframe as bf
import pandas as pd
df1 = pd.DataFrame(
        [
            ['chr1', 1, 1]
        ], 
        columns=['chrom','start','end']
    ).astype({"start": pd.Int64Dtype(), "end": pd.Int64Dtype()})

df2 = pd.DataFrame(
    [
        ['chr1', 1, 2]
    ], 
    columns=['chrom','start','end']
).astype({"start": pd.Int64Dtype(), "end": pd.Int64Dtype()})

b = bf.overlap(
    df1,
    df2,
    on=None,
    how="left",
    return_index=True,
    return_input=True,
)
print(b)
b = bf.overlap(
    df2,
    df1,
    on=None,
    how="left",
    return_index=True,
    return_input=True,
)
print(b)
```

Result : 
```
   index chrom  start  end  index_ chrom_  start_  end_
0      0  chr1      1    1       0   chr1       1     2
   index chrom  start  end  index_ chrom_  start_  end_
0      0  chr1      1    2       0   chr1       1     1

```