### PR TITLE
Closest improved

### DIFF
--- a/bioframe/core/arrops.py
+++ b/bioframe/core/arrops.py
@@ -709,6 +709,9 @@ def closest_intervals(
         [left_dists, right_dists, np.zeros(overlap_ids.shape[0])]
     )
 
+    if len(closest_ids)==0:
+        return np.empty((0,2), dtype=int)
+
     # Sort by distance to set 1 intervals and, if present, by the tie-breaking
     # data array.
     if tie_arr is None:

--- a/bioframe/extras.py
+++ b/bioframe/extras.py
@@ -513,7 +513,9 @@ def pair_by_distance(
     idxs["intervening"] = (
         np.abs(idxs[f"index{suffixes[0]}"] - idxs[f"index{suffixes[1]}"]) - 1
     )
-    idxs = idxs[(idxs['intervening']<=max_intervening) & (idxs['intervening']>=min_intervening)]
+    idxs = idxs[
+        (idxs['intervening']<=max_intervening) & (idxs['intervening']>=min_intervening)
+        ]
 
     left_ivals = (
         df.iloc[idxs[f"index{suffixes[0]}"].values]

--- a/bioframe/extras.py
+++ b/bioframe/extras.py
@@ -513,9 +513,7 @@ def pair_by_distance(
     idxs["intervening"] = (
         np.abs(idxs[f"index{suffixes[0]}"] - idxs[f"index{suffixes[1]}"]) - 1
     )
-    idxs = idxs.query(
-        f"intervening<={max_intervening} and intervening>={min_intervening}"
-    )
+    idxs = idxs[(idxs['intervening']<=max_intervening) & (idxs['intervening']>=min_intervening)]
 
     left_ivals = (
         df.iloc[idxs[f"index{suffixes[0]}"].values]

--- a/bioframe/ops.py
+++ b/bioframe/ops.py
@@ -300,7 +300,6 @@ def _overlap_intidxs(df1, df2, how="left", cols1=None, cols2=None, on=None):
         both_groups_nonempty = (df1_group_idxs.size > 0) and (df2_group_idxs.size > 0)
 
         if both_groups_nonempty:
-
             overlap_idxs_loc = arrops.overlap_intervals(
                 starts1[df1_group_idxs],
                 ends1[df1_group_idxs],
@@ -530,10 +529,9 @@ def overlap(
             df2[ek2].values[events2],
         )
 
-        df_overlap = pd.DataFrame({
-            overlap_col_sk1: overlap_start,
-            overlap_col_ek1: overlap_end
-        })
+        df_overlap = pd.DataFrame(
+            {overlap_col_sk1: overlap_start, overlap_col_ek1: overlap_end}
+        )
 
     df_input_1 = None
     df_input_2 = None
@@ -547,8 +545,8 @@ def overlap(
 
     # Masking non-overlapping regions if using non-inner joins.
     if how != "inner":
-        is_na_left = (events1 == -1)
-        is_na_right = (events2 == -1)
+        is_na_left = events1 == -1
+        is_na_right = events2 == -1
         any_na_left = is_na_left.any()
         any_na_right = is_na_right.any()
         df_index_1[is_na_left] = None
@@ -556,19 +554,23 @@ def overlap(
 
         if df_input_1 is not None:
             if ensure_int and any_na_left:
-                df_input_1 = df_input_1.astype({
-                    sk1 + suffixes[0]: _to_nullable_dtype(df1[sk1].dtype),
-                    ek1 + suffixes[0]: _to_nullable_dtype(df1[ek1].dtype),
-                })
+                df_input_1 = df_input_1.astype(
+                    {
+                        sk1 + suffixes[0]: _to_nullable_dtype(df1[sk1].dtype),
+                        ek1 + suffixes[0]: _to_nullable_dtype(df1[ek1].dtype),
+                    }
+                )
             if any_na_left:
                 df_input_1[is_na_left] = None
 
         if df_input_2 is not None:
             if ensure_int and any_na_right:
-                df_input_2 = df_input_2.astype({
-                    sk2 + suffixes[1]: _to_nullable_dtype(df2[sk2].dtype),
-                    ek2 + suffixes[1]: _to_nullable_dtype(df2[ek2].dtype),
-                })
+                df_input_2 = df_input_2.astype(
+                    {
+                        sk2 + suffixes[1]: _to_nullable_dtype(df2[sk2].dtype),
+                        ek2 + suffixes[1]: _to_nullable_dtype(df2[ek2].dtype),
+                    }
+                )
             if any_na_right:
                 df_input_2[is_na_right] = None
 
@@ -1066,27 +1068,29 @@ def _closest_intidxs(
             direction=direction_arr,
         )
 
-        na_idxs = np.isin(np.arange(len(df1_group_idxs)), 
-            closest_idxs_group[:, 0], 
-            invert=True)
+        na_idxs = np.isin(
+            np.arange(len(df1_group_idxs)), closest_idxs_group[:, 0], invert=True
+        )
 
         # 1) Convert local per-chromosome indices into the
         # indices of the original table,
         # 2) Fill in the intervals that do not have closest values.
-        closest_idxs_group = np.concatenate([
-            np.vstack(
-                [
-                    df1_group_idxs.values[closest_idxs_group[:, 0]],
-                    df2_group_idxs.values[closest_idxs_group[:, 1]],
-                ]
-            ).T,
-            np.vstack(
-                [
-                    df1_group_idxs.values[na_idxs],
-                    -1 * np.ones_like(df1_group_idxs.values[na_idxs]),
-                ]
-            ).T
-        ])
+        closest_idxs_group = np.concatenate(
+            [
+                np.vstack(
+                    [
+                        df1_group_idxs.values[closest_idxs_group[:, 0]],
+                        df2_group_idxs.values[closest_idxs_group[:, 1]],
+                    ]
+                ).T,
+                np.vstack(
+                    [
+                        df1_group_idxs.values[na_idxs],
+                        -1 * np.ones_like(df1_group_idxs.values[na_idxs]),
+                    ]
+                ).T,
+            ]
+        )
 
         closest_intidxs.append(closest_idxs_group)
 
@@ -1740,7 +1744,10 @@ def complement(df, view_df=None, view_name_col="name", cols=None, cols_view=None
         df_group_idxs = df_groups[group_key].values
         df_group = df.loc[df_group_idxs]
 
-        (complement_starts_group, complement_ends_group,) = arrops.complement_intervals(
+        (
+            complement_starts_group,
+            complement_ends_group,
+        ) = arrops.complement_intervals(
             df_group[sk].values.astype(np.int64),
             df_group[ek].values.astype(np.int64),
             bounds=(region_start, region_end),

--- a/bioframe/ops.py
+++ b/bioframe/ops.py
@@ -1066,14 +1066,25 @@ def _closest_intidxs(
             direction=direction_arr,
         )
 
-        # Convert local per-chromosome indices into the
-        # indices of the original table.
-        closest_idxs_group = np.vstack(
-            [
-                df1_group_idxs.values[closest_idxs_group[:, 0]],
-                df2_group_idxs.values[closest_idxs_group[:, 1]],
-            ]
-        ).T
+        na_idxs = np.isin(np.arange(len(df1_group_idxs)), closest_idxs_group[:, 0], invert=True)
+
+        # 1) Convert local per-chromosome indices into the
+        # indices of the original table,
+        # 2) Fill in the intervals that do not have closest values.
+        closest_idxs_group = np.concatenate([
+            np.vstack(
+                [
+                    df1_group_idxs.values[closest_idxs_group[:, 0]],
+                    df2_group_idxs.values[closest_idxs_group[:, 1]],
+                ]
+            ).T,
+            np.vstack(
+                [
+                    df1_group_idxs.values[na_idxs],
+                    -1 * np.ones_like(df1_group_idxs.values[na_idxs]),
+                ]
+            ).T
+        ])
 
         closest_intidxs.append(closest_idxs_group)
 
@@ -1219,9 +1230,6 @@ def closest(
         cols2=cols2,
     )
     na_mask = closest_df_idxs[:, 1] == -1
-
-    if len(closest_df_idxs) == 0:
-        return  # case of no closest intervals
 
     # Generate output tables.
     df_index_1 = None

--- a/bioframe/ops.py
+++ b/bioframe/ops.py
@@ -1066,7 +1066,9 @@ def _closest_intidxs(
             direction=direction_arr,
         )
 
-        na_idxs = np.isin(np.arange(len(df1_group_idxs)), closest_idxs_group[:, 0], invert=True)
+        na_idxs = np.isin(np.arange(len(df1_group_idxs)), 
+            closest_idxs_group[:, 0], 
+            invert=True)
 
         # 1) Convert local per-chromosome indices into the
         # indices of the original table,

--- a/bioframe/ops.py
+++ b/bioframe/ops.py
@@ -511,8 +511,8 @@ def overlap(
     index_col = return_index if isinstance(return_index, str) else "index"
     index_col_1 = index_col + suffixes[0]
     index_col_2 = index_col + suffixes[1]
-    df_index_1 = pd.DataFrame({index_col_1: df1.index[events1]})
-    df_index_2 = pd.DataFrame({index_col_2: df2.index[events2]})
+    df_index_1 = pd.DataFrame({index_col_1: df1.index[events1]}, dtype=pd.Int64Dtype())
+    df_index_2 = pd.DataFrame({index_col_2: df2.index[events2]}, dtype=pd.Int64Dtype())
 
     df_overlap = None
     if return_overlap:

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -65,7 +65,6 @@ def mock_bioframe(num_entries=100):
 
 ############# tests #####################
 def test_trim():
-
     ### trim with view_df
     view_df = pd.DataFrame(
         [
@@ -216,7 +215,6 @@ def test_trim():
 
 
 def test_expand():
-
     d = """chrom  start  end
          0  chr1      1    5
          1  chr1     50   55
@@ -289,6 +287,7 @@ def test_expand():
     )
     pd.testing.assert_frame_equal(df, fake_expanded)
 
+
 def test_expand_amount_args():
     d = """chrom  start  end
          0  chr1      3    5
@@ -298,8 +297,8 @@ def test_expand_amount_args():
     with pytest.raises(ValueError):
         bioframe.expand(df, pad=10, scale=2.0)
 
-def test_overlap():
 
+def test_overlap():
     ### test consistency of overlap(how='inner') with pyranges.join ###
     ### note does not test overlap_start or overlap_end columns of bioframe.overlap
     df1 = mock_bioframe()
@@ -467,17 +466,14 @@ def test_overlap():
         columns=["chrom2", "start2", "end2", "strand", "animal"],
     ).astype({"start2": pd.Int64Dtype(), "end2": pd.Int64Dtype()})
 
-    assert (
-        bioframe.overlap(
-            df1,
-            df2,
-            how="outer",
-            cols2=["chrom2", "start2", "end2"],
-            return_index=True,
-            keep_order=False,
-        ).shape
-        == (3, 12)
-    )
+    assert bioframe.overlap(
+        df1,
+        df2,
+        how="outer",
+        cols2=["chrom2", "start2", "end2"],
+        return_index=True,
+        keep_order=False,
+    ).shape == (3, 12)
 
     ### result of overlap should still have bedframe-like properties
     overlap_df = bioframe.overlap(
@@ -542,14 +538,14 @@ def test_overlap_preserves_coord_dtypes():
     ).astype({"start": pd.Int64Dtype(), "end": pd.Int64Dtype()})
 
     # inner join - left keeps non-nullable numpy uint32
-    overlap_dtypes = bioframe.overlap(df1,  df2, ensure_int=False, how="inner").dtypes
+    overlap_dtypes = bioframe.overlap(df1, df2, ensure_int=False, how="inner").dtypes
     for col in ["start", "end"]:
         assert overlap_dtypes[col] == np.uint32
     for col in ["start_", "end_"]:
         assert overlap_dtypes[col] == pd.Int64Dtype()
 
     # outer join - left uint32 gets cast to numpy float64 because of NaNs on left
-    overlap_dtypes = bioframe.overlap(df1,  df2, how="outer", ensure_int=False).dtypes
+    overlap_dtypes = bioframe.overlap(df1, df2, how="outer", ensure_int=False).dtypes
     assert overlap_dtypes["start"] == np.float64
     assert overlap_dtypes["end"] == np.float64
     assert overlap_dtypes["start_"] == pd.Int64Dtype()
@@ -567,16 +563,20 @@ def test_overlap_preserves_coord_dtypes():
     # convert coords to nullable *after* joining
     # inner join - uint32 output becomes UInt32
     # outer join - float64 output becomes Int64
-    overlap_dtypes = bioframe.overlap(
-        df1, df2, ensure_int=False, how="inner"
-    ).convert_dtypes().dtypes
+    overlap_dtypes = (
+        bioframe.overlap(df1, df2, ensure_int=False, how="inner")
+        .convert_dtypes()
+        .dtypes
+    )
     assert overlap_dtypes["start"] == pd.UInt32Dtype()
     assert overlap_dtypes["end"] == pd.UInt32Dtype()
     assert overlap_dtypes["start_"] == pd.Int64Dtype()
     assert overlap_dtypes["end_"] == pd.Int64Dtype()
-    overlap_dtypes = bioframe.overlap(
-        df1, df2, ensure_int=False, how="outer"
-    ).convert_dtypes().dtypes
+    overlap_dtypes = (
+        bioframe.overlap(df1, df2, ensure_int=False, how="outer")
+        .convert_dtypes()
+        .dtypes
+    )
     assert overlap_dtypes["start"] == pd.Int64Dtype()
     assert overlap_dtypes["end"] == pd.Int64Dtype()
     assert overlap_dtypes["start_"] == pd.Int64Dtype()
@@ -593,27 +593,19 @@ def test_overlap_ensure_int():
         columns=["chrom", "start", "end", "strand"],
     ).astype({"start": np.uint32, "end": np.uint32})
     df2 = pd.DataFrame(
-        [
-            ["chr1", 6, 10, "+"],
-            [pd.NA, pd.NA, pd.NA, "-"],
-            ["chrX", 7, 10, "-"]
-        ],
+        [["chr1", 6, 10, "+"], [pd.NA, pd.NA, pd.NA, "-"], ["chrX", 7, 10, "-"]],
         columns=["chrom", "start", "end", "strand"],
     ).astype({"start": pd.Int64Dtype(), "end": pd.Int64Dtype()})
 
     # inner join
-    overlap_dtypes = bioframe.overlap(
-        df1,  df2, how="inner", ensure_int=True
-    ).dtypes
+    overlap_dtypes = bioframe.overlap(df1, df2, how="inner", ensure_int=True).dtypes
     for col in ["start", "end"]:
         assert overlap_dtypes[col] == np.uint32
     for col in ["start_", "end_"]:
         assert overlap_dtypes[col] == pd.Int64Dtype()
 
     # outer join - left uint32 gets cast to UInt32 before the join
-    overlap_dtypes = bioframe.overlap(
-        df1,  df2, how="outer", ensure_int=True
-    ).dtypes
+    overlap_dtypes = bioframe.overlap(df1, df2, how="outer", ensure_int=True).dtypes
     for col in ["start", "end"]:
         assert overlap_dtypes[col] == pd.UInt32Dtype()
     for col in ["start_", "end_"]:
@@ -1078,10 +1070,8 @@ def test_closest():
     )
 
     df2 = pd.DataFrame(
-        [["chr1", 1, 2],
-         ["chr1", 2, 8],
-         ["chr1", 10, 11]],
-        columns=["chrom", "start", "end"]
+        [["chr1", 1, 2], ["chr1", 2, 8], ["chr1", 10, 11]],
+        columns=["chrom", "start", "end"],
     )
 
     ### closest(df1, df2, k=1, direction_col="strand") ###
@@ -1113,13 +1103,18 @@ def test_closest():
             "distance": pd.Int64Dtype(),
         }
     )
-    pd.testing.assert_frame_equal(df,
-        bioframe.closest(df1, df2,
-                k=1,
-                ignore_upstream=False,
-                ignore_downstream=True,
-                ignore_overlaps=True,
-                direction_col="strand"))
+    pd.testing.assert_frame_equal(
+        df,
+        bioframe.closest(
+            df1,
+            df2,
+            k=1,
+            ignore_upstream=False,
+            ignore_downstream=True,
+            ignore_overlaps=True,
+            direction_col="strand",
+        ),
+    )
 
     ### closest(df1, df2, k=1, ignore_upstream=True, ignore_downstream=False,
     ### ignore_overlaps=True, direction_col="strand") ###
@@ -1134,17 +1129,119 @@ def test_closest():
             "distance": pd.Int64Dtype(),
         }
     )
-    pd.testing.assert_frame_equal(df,
-        bioframe.closest(df1, df2,
-                k=1,
-                ignore_upstream=True,
-                ignore_downstream=False,
-                ignore_overlaps=True,
-                direction_col="strand"))
+    pd.testing.assert_frame_equal(
+        df,
+        bioframe.closest(
+            df1,
+            df2,
+            k=1,
+            ignore_upstream=True,
+            ignore_downstream=False,
+            ignore_overlaps=True,
+            direction_col="strand",
+        ),
+    )
+
+    ### closest(df1, df2, k=1, ignore_upstream=False, ignore_downstream=True,
+    ### ignore_overlaps=True) when upstream region is present ###
+    df1 = pd.DataFrame(
+        [
+            ["chr1", 3, 5],
+        ],
+        columns=["chrom", "start", "end"],
+    )
+
+    df2 = pd.DataFrame(
+        [["chr1", 1, 2], ["chr1", 10, 11]], columns=["chrom", "start", "end"]
+    )
+
+    d = """chrom  start  end chrom_  start_  end_  distance
+        0    chr1        3      5    chr1        1      2         1
+        """
+    df = pd.read_csv(StringIO(d), sep=r"\s+").astype(
+        {
+            "start_": pd.Int64Dtype(),
+            "end_": pd.Int64Dtype(),
+            "distance": pd.Int64Dtype(),
+        }
+    )
+    pd.testing.assert_frame_equal(
+        df,
+        bioframe.closest(
+            df1,
+            df2,
+            k=1,
+            ignore_upstream=False,
+            ignore_downstream=True,
+            ignore_overlaps=True,
+        ),
+    )
+
+    ### closest(df1, df2, k=1, ignore_upstream=False, ignore_downstream=True,
+    ### ignore_overlaps=True) when upstream region is absent ###
+
+    df2 = pd.DataFrame(
+        [["chr1", 5, 6], ["chr1", 10, 11]], columns=["chrom", "start", "end"]
+    )
+
+    d = """chrom  start  end chrom_  start_  end_  distance
+        0    chr1        3      5    NaN        NaN      NaN         NaN
+        """
+    df = pd.read_csv(StringIO(d), sep=r"\s+").astype(
+        {
+            "chrom_": "O",
+            "start_": pd.Int64Dtype(),
+            "end_": pd.Int64Dtype(),
+            "distance": pd.Int64Dtype(),
+        }
+    )
+    pd.testing.assert_frame_equal(
+        df,
+        bioframe.closest(
+            df1,
+            df2,
+            k=1,
+            ignore_upstream=False,
+            ignore_downstream=True,
+            ignore_overlaps=True,
+        ),
+    )
+
+    ### closest(df1, df2, k=1, ignore_upstream=True, ignore_downstream=False,
+    ### ignore_overlaps=True) when upstream region is absent ###
+
+    df2 = pd.DataFrame(
+        [
+            ["chr1", 1, 2],
+        ],
+        columns=["chrom", "start", "end"],
+    )
+
+    d = """chrom  start  end chrom_  start_  end_  distance
+        0    chr1        3      5    NaN        NaN      NaN         NaN
+        """
+    df = pd.read_csv(StringIO(d), sep=r"\s+").astype(
+        {
+            "chrom_": "O",
+            "start_": pd.Int64Dtype(),
+            "end_": pd.Int64Dtype(),
+            "distance": pd.Int64Dtype(),
+        }
+    )
+    pd.testing.assert_frame_equal(
+        df,
+        bioframe.closest(
+            df1,
+            df2,
+            k=1,
+            ignore_upstream=True,
+            ignore_downstream=False,
+            ignore_overlaps=True,
+        ),
+    )
 
 
 def test_coverage():
-
     #### coverage does not exceed length of original interval
     df1 = pd.DataFrame([["chr1", 3, 8]], columns=["chrom", "start", "end"])
     df2 = pd.DataFrame([["chr1", 2, 10]], columns=["chrom", "start", "end"])
@@ -1180,8 +1277,7 @@ def test_coverage():
          0  chr1     3       8     5"""
     df = pd.read_csv(StringIO(d), sep=r"\s+")
     pd.testing.assert_frame_equal(
-        df,
-        bioframe.coverage(df1, df2, cols1=cols1, cols2=cols2)
+        df, bioframe.coverage(df1, df2, cols1=cols1, cols2=cols2)
     )
 
     ### coverage of NA interval returns zero for coverage
@@ -1461,7 +1557,6 @@ def test_subtract():
 
 
 def test_setdiff():
-
     cols1 = ["chrom1", "start", "end"]
     cols2 = ["chrom2", "start", "end"]
     df1 = pd.DataFrame(
@@ -1624,7 +1719,12 @@ def test_count_overlaps():
 
     counts_nans_inserted_after = (
         pd.concat([pd.DataFrame([pd.NA]), counts_no_nans, pd.DataFrame([pd.NA])])
-    ).astype({"start": pd.Int64Dtype(), "end": pd.Int64Dtype(),})[
+    ).astype(
+        {
+            "start": pd.Int64Dtype(),
+            "end": pd.Int64Dtype(),
+        }
+    )[
         ["chrom1", "start", "end", "strand", "animal", "count"]
     ]
 
@@ -1666,7 +1766,6 @@ def test_count_overlaps():
 
 
 def test_assign_view():
-
     ## default assignment case
     view_df = pd.DataFrame(
         [
@@ -1785,7 +1884,6 @@ def test_assign_view():
 
 
 def test_sort_bedframe():
-
     view_df = pd.DataFrame(
         [
             ["chrX", 1, 8, "oranges"],


### PR DESCRIPTION
Problem: If the segment does not have closest (e.g., in ignore_upstream=True setting), it will simply drop out of output table.

Solution: Added checking the indexes of df1 that are absent form the final returned hits

Why it was not observed before: No detiled testing for options ignore_upstream/ignore_downstream/ignore_overlap and their combinations.
If df1 has a segment from a chromosome X and df2 has a segment from it, but they are in an arrangements that won't produce a hit, this segment will be dropped out of df1 output.

Dragged modifications: overlap returned float indexes with failing the tests (numpy v1.22.4, pandas v1.5.2). Solution added for robustness of code across different software versions.