### PR TITLE
Fix typo: DatFrames -> DataFrames in docs/guide-intervalops.md

### DIFF
--- a/docs/guide-intervalops.md
+++ b/docs/guide-intervalops.md
@@ -34,7 +34,7 @@ import bioframe.vis
 ## DataFrames & BedFrames
 
 ```{eval-rst}
-The core objects in bioframe are pandas DatFrames of genomic intervals, or BedFrames. These can either be defined directly with :py:class:`pandas.DataFrame`:
+The core objects in bioframe are pandas DataFrames of genomic intervals, or BedFrames. These can either be defined directly with :py:class:`pandas.DataFrame`:
 ```
 ```{code-cell} ipython3
 df1 = pd.DataFrame([


### PR DESCRIPTION
Fixing a small typo in the documentation file _docs/guide-intervalops.md_, changing "DatFrames" to "DataFrames" in the **DataFrames & BedFrames** section.