### PR TITLE
Fix Issue #88: add error chaining for is_viewframe

### DIFF
--- a/bioframe/core/checks.py
+++ b/bioframe/core/checks.py
@@ -228,9 +228,11 @@ def is_viewframe(region_df, raise_errors=False, view_name_col="name", cols=None)
             raise TypeError("Invalid view: invalid column names")
         return False
 
-    if not is_bedframe(region_df, cols=cols):
+    try:
+        is_bedframe(region_df, raise_errors=True, cols=cols)
+    except Exception as e:
         if raise_errors:
-            raise ValueError("Invalid view: not a bedframe")
+            raise ValueError("Invalid view: not a bedframe") from e
         return False
 
     if pd.isna(region_df).values.any():

--- a/tests/test_core_checks.py
+++ b/tests/test_core_checks.py
@@ -431,6 +431,22 @@ def test_is_viewframe():
     )
     assert is_viewframe(df1)
 
+    # error chaining with is_bedframe
+    df1 = pd.DataFrame(
+        [
+            ["chr1", 20, 10, "chr1p"],
+            ["chr1", 25, 20, "chr1q"],
+            ["chr2", 30, 20, "chr2q"],
+        ],
+        columns=["chrom", "start", "end", "name"],
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        is_viewframe(df1, raise_errors=True)
+
+    assert "Invalid view: not a bedframe" in str(excinfo.value)
+    assert "Invalid bedframe: starts exceed ends for" in str(excinfo.value.__cause__)
+
 
 def test_is_sorted():
     view_df = pd.DataFrame(


### PR DESCRIPTION
issue #88 : added error chaining to 'is_viewframe' function so that the aspect of 'is_bedframe' not satified will be now displayed in the error message