### PR TITLE
Restore one-sided return_input options in overlap

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,11 @@
 
 ## [Upcoming release](https://github.com/open2c/bioframe/compare/v0.8.0...HEAD)
 
+Bug fixes:
+
+- `overlap` again honors `return_input=1`/`"left"` and `return_input=2`/`"right"` to return only
+  one side's columns; unsupported values now raise `ValueError` instead of silently returning both.
+
 ## v0.8.0
 
 Date: 2025-04-08

--- a/src/bioframe/ops.py
+++ b/src/bioframe/ops.py
@@ -387,8 +387,11 @@ def overlap(
         outer: use the union of the set of intervals from df1 and df2
         inner: use intersection of the set of intervals from df1 and df2
 
-    return_input : bool, optional
-        If True, return columns from input dfs. Default True.
+    return_input : bool, int, or str, optional
+        Controls which input columns are returned. If True (default), return
+        columns from both input dataframes; if False, return neither. To return
+        only one side, pass ``1``, ``"1"``, or ``"left"`` for ``df1``, or ``2``,
+        ``"2"``, or ``"right"`` for ``df2``.
 
     return_index : bool, optional
         If True, return indicies of overlapping pairs as two new columns
@@ -461,6 +464,20 @@ def overlap(
         _verify_columns(df1, on)
         _verify_columns(df2, on)
 
+    if return_input is True:
+        return_left = return_right = True
+    elif return_input is False:
+        return_left = return_right = False
+    elif return_input in (1, "1", "left"):
+        return_left, return_right = True, False
+    elif return_input in (2, "2", "right"):
+        return_left, return_right = False, True
+    else:
+        raise ValueError(
+            "return_input must be one of True, False, 1, 2, 'left', 'right'; "
+            f"got {return_input!r}"
+        )
+
     events1, events2 = _overlap_intidxs(
         df1,
         df2,
@@ -499,11 +516,11 @@ def overlap(
 
     df_input_1 = None
     df_input_2 = None
-    if return_input:
+    if return_left:
         df_input_1 = df1.iloc[events1].reset_index(drop=True)
         df_input_1.columns = [c + suffixes[0] for c in df_input_1.columns]
 
-    if return_input:
+    if return_right:
         df_input_2 = df2.iloc[events2].reset_index(drop=True)
         df_input_2.columns = [c + suffixes[1] for c in df_input_2.columns]
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -772,6 +772,46 @@ def test_overlap():
         )
 
 
+def test_overlap_return_input():
+    df1 = pd.DataFrame(
+        [["chr1", 3, 8], ["chr1", 12, 16]],
+        columns=["chrom", "start", "end"],
+    )
+    df2 = pd.DataFrame(
+        [["chr1", 5, 10]],
+        columns=["chrom", "start", "end"],
+    )
+    left_cols = ["chrom", "start", "end"]
+    right_cols = ["chrom_", "start_", "end_"]
+
+    # True / False return both / neither sides
+    assert (
+        list(bioframe.overlap(df1, df2, how="inner", return_input=True).columns)
+        == left_cols + right_cols
+    )
+    assert (
+        list(bioframe.overlap(df1, df2, how="inner", return_input=False).columns) == []
+    )
+
+    # 1 / "1" / "left" return only df1 columns
+    for val in (1, "1", "left"):
+        assert (
+            list(bioframe.overlap(df1, df2, how="inner", return_input=val).columns)
+            == left_cols
+        )
+
+    # 2 / "2" / "right" return only df2 columns
+    for val in (2, "2", "right"):
+        assert (
+            list(bioframe.overlap(df1, df2, how="inner", return_input=val).columns)
+            == right_cols
+        )
+
+    # values outside the supported set raise instead of silently returning both
+    with pytest.raises(ValueError):
+        bioframe.overlap(df1, df2, how="inner", return_input="both")
+
+
 def test_overlap_preserves_coord_dtypes():
     df1 = pd.DataFrame(
         [


### PR DESCRIPTION
Closes #197.

`overlap(..., return_input=...)` used to accept `1`/`"1"`/`"left"` to return only df1's columns and `2`/`"2"`/`"right"` to return only df2's, but a refactor reduced `return_input` to a plain truthiness check, so any non-`False` value silently returned both sides. This restores the documented options and makes unsupported values raise instead of failing silently.

Changes:
- `overlap` resolves `return_input` into left/right flags and raises `ValueError` for values outside `{True, False, 1, 2, "1", "2", "left", "right"}`.
- Documented the accepted values in the docstring.
- Added `test_overlap_return_input` covering both / neither / left-only / right-only and the error case.
- Changelog note under the upcoming release.

| return_input | columns returned |
| --- | --- |
| True (default) | both sides |
| False | neither |
| 1 / "1" / "left" | df1 only |
| 2 / "2" / "right" | df2 only |

`pytest tests/test_ops.py` passes (17 tests).
